### PR TITLE
feat(admin): add cross-org user membership management

### DIFF
--- a/apps/backend/src/__tests__/app.authorization.integration.test.ts
+++ b/apps/backend/src/__tests__/app.authorization.integration.test.ts
@@ -509,6 +509,10 @@ describe('authorization integration (app.request)', () => {
     expect(json.paths['/api/admin/editions/{id}/rules/presign']).toBeDefined();
     expect(json.paths['/api/admin/editions/{id}/rules']).toBeDefined();
     expect(json.paths['/api/admin/participations/{id}']).toBeDefined();
+    expect(json.paths['/api/admin/users']).toBeDefined();
+    expect(json.paths['/api/admin/users/{userId}/memberships']).toBeDefined();
+    expect(json.paths['/api/admin/memberships/{memberId}/role']).toBeDefined();
+    expect(json.paths['/api/admin/memberships/{memberId}']).toBeDefined();
 
     const seriesGet = json.paths['/api/series'] as {
       get?: { parameters?: Array<{ name?: string; in?: string }> };
@@ -575,6 +579,10 @@ describe('authorization integration (app.request)', () => {
         path: '/api/admin/editions/00000000-0000-0000-0000-000000000010/participations',
         headers: { 'x-role': 'admin' },
       },
+      {
+        path: '/api/admin/users',
+        headers: { 'x-role': 'admin' },
+      },
     ] as const;
 
     for (const testCase of cases) {
@@ -634,6 +642,10 @@ describe('authorization integration (app.request)', () => {
       },
       {
         path: '/api/admin/editions/00000000-0000-0000-0000-000000000010/participations',
+        headers: { 'x-role': 'admin' },
+      },
+      {
+        path: '/api/admin/users',
         headers: { 'x-role': 'admin' },
       },
     ] as const;

--- a/apps/backend/src/__tests__/app.issue11.integration.test.ts
+++ b/apps/backend/src/__tests__/app.issue11.integration.test.ts
@@ -575,6 +575,23 @@ describe('issue #11 api integration', () => {
     expect(duplicateRes.status).toBe(409);
 
     enqueueDb(
+      [{ id: 'u-1' }],
+      [{ id: 'org-2' }],
+      [],
+      Promise.reject({ code: '23505', constraint: 'member_org_user_unique' }),
+    );
+    const raceDuplicateRes = await app.request('/api/admin/users/u-1/memberships', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-role': 'admin',
+      },
+      body: JSON.stringify({ organizationId: 'org-2', role: 'member' }),
+    });
+    expect(raceDuplicateRes.status).toBe(409);
+    expect(await raceDuplicateRes.json()).toEqual({ error: 'Membership already exists' });
+
+    enqueueDb(
       [{ id: 'm-2', userId: 'u-1', organizationId: 'org-2', role: 'member' }],
       [
         {

--- a/apps/backend/src/__tests__/app.issue11.integration.test.ts
+++ b/apps/backend/src/__tests__/app.issue11.integration.test.ts
@@ -449,6 +449,195 @@ describe('issue #11 api integration', () => {
     expect(deleteRes.status).toBe(409);
   });
 
+  it('admin users API: list and memberships CRUD', async () => {
+    const app = createApp();
+
+    enqueueDb(
+      [{ total: 2 }],
+      [
+        {
+          id: 'u-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          isAdmin: false,
+          createdAt: '2026-03-20T00:00:00.000Z',
+          organizationCount: 3,
+        },
+        {
+          id: 'u-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          isAdmin: true,
+          createdAt: '2026-03-21T00:00:00.000Z',
+          organizationCount: 1,
+        },
+      ],
+    );
+
+    const listRes = await app.request('/api/admin/users?page=1&pageSize=10&q=ali&sort=email:asc', {
+      headers: { 'x-role': 'admin' },
+    });
+    expect(listRes.status).toBe(200);
+    expect(await listRes.json()).toEqual({
+      data: [
+        {
+          id: 'u-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          isAdmin: false,
+          createdAt: '2026-03-20T00:00:00.000Z',
+          organizationCount: 3,
+        },
+        {
+          id: 'u-2',
+          name: 'Bob',
+          email: 'bob@example.com',
+          isAdmin: true,
+          createdAt: '2026-03-21T00:00:00.000Z',
+          organizationCount: 1,
+        },
+      ],
+      pagination: {
+        page: 1,
+        pageSize: 10,
+        total: 2,
+        totalPages: 1,
+        hasNext: false,
+        hasPrev: false,
+      },
+    });
+
+    enqueueDb(
+      [{ id: 'u-1' }],
+      [
+        {
+          memberId: 'm-1',
+          organizationId: 'org-1',
+          organizationName: 'Org One',
+          organizationSlug: 'org-one',
+          role: 'owner',
+          createdAt: '2026-03-20T00:00:00.000Z',
+        },
+      ],
+    );
+
+    const membershipsRes = await app.request('/api/admin/users/u-1/memberships', {
+      headers: { 'x-role': 'admin' },
+    });
+    expect(membershipsRes.status).toBe(200);
+    expect(await membershipsRes.json()).toEqual({
+      data: [
+        {
+          memberId: 'm-1',
+          organizationId: 'org-1',
+          organizationName: 'Org One',
+          organizationSlug: 'org-one',
+          role: 'owner',
+          createdAt: '2026-03-20T00:00:00.000Z',
+        },
+      ],
+    });
+
+    enqueueDb(
+      [{ id: 'u-1' }],
+      [{ id: 'org-2' }],
+      [],
+      [
+        {
+          id: 'm-2',
+          userId: 'u-1',
+          organizationId: 'org-2',
+          role: 'member',
+          createdAt: '2026-03-22T00:00:00.000Z',
+        },
+      ],
+    );
+
+    const createRes = await app.request('/api/admin/users/u-1/memberships', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-role': 'admin',
+      },
+      body: JSON.stringify({ organizationId: 'org-2', role: 'member' }),
+    });
+    expect(createRes.status).toBe(201);
+
+    enqueueDb([{ id: 'u-1' }], [{ id: 'org-2' }], [{ id: 'm-2' }]);
+    const duplicateRes = await app.request('/api/admin/users/u-1/memberships', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-role': 'admin',
+      },
+      body: JSON.stringify({ organizationId: 'org-2', role: 'member' }),
+    });
+    expect(duplicateRes.status).toBe(409);
+
+    enqueueDb(
+      [{ id: 'm-2', userId: 'u-1', organizationId: 'org-2', role: 'member' }],
+      [
+        {
+          id: 'm-2',
+          userId: 'u-1',
+          organizationId: 'org-2',
+          role: 'owner',
+          createdAt: '2026-03-22T00:00:00.000Z',
+        },
+      ],
+    );
+    const updateRes = await app.request('/api/admin/memberships/m-2/role', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'x-role': 'admin',
+      },
+      body: JSON.stringify({ role: 'owner' }),
+    });
+    expect(updateRes.status).toBe(200);
+
+    enqueueDb(
+      [{ id: 'm-owner', userId: 'u-1', organizationId: 'org-1', role: 'owner' }],
+      [{ total: 1 }],
+    );
+    const demoteLastOwnerRes = await app.request('/api/admin/memberships/m-owner/role', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        'x-role': 'admin',
+      },
+      body: JSON.stringify({ role: 'member' }),
+    });
+    expect(demoteLastOwnerRes.status).toBe(409);
+
+    enqueueDb([{ id: 'm-2', userId: 'u-1', organizationId: 'org-2', role: 'member' }], []);
+    const deleteRes = await app.request('/api/admin/memberships/m-2', {
+      method: 'DELETE',
+      headers: { 'x-role': 'admin' },
+    });
+    expect(deleteRes.status).toBe(204);
+
+    enqueueDb(
+      [{ id: 'm-owner', userId: 'u-1', organizationId: 'org-1', role: 'owner' }],
+      [{ total: 1 }],
+    );
+    const deleteLastOwnerRes = await app.request('/api/admin/memberships/m-owner', {
+      method: 'DELETE',
+      headers: { 'x-role': 'admin' },
+    });
+    expect(deleteLastOwnerRes.status).toBe(409);
+  });
+
+  it('admin users API forbids non-admin access', async () => {
+    const app = createApp();
+
+    const res = await app.request('/api/admin/users', {
+      headers: { 'x-role': 'member' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
   it('GET /api/editions/:id/submissions includes participation.universityName', async () => {
     const app = createApp();
 
@@ -832,6 +1021,10 @@ describe('issue #11 api integration', () => {
     expect(json.paths['/api/admin/editions/{id}/rules']).toBeDefined();
     expect(json.paths['/api/university/members/{id}/role']).toBeDefined();
     expect(json.paths['/api/university/members/{id}']).toBeDefined();
+    expect(json.paths['/api/admin/users']).toBeDefined();
+    expect(json.paths['/api/admin/users/{userId}/memberships']).toBeDefined();
+    expect(json.paths['/api/admin/memberships/{memberId}/role']).toBeDefined();
+    expect(json.paths['/api/admin/memberships/{memberId}']).toBeDefined();
 
     const myParticipationsPath = json.paths['/api/editions/{id}/my-participations'] as {
       get?: { responses?: Record<string, unknown> };

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -11,6 +11,7 @@ import { adminParticipationRoutes } from './routes/admin/participations.js';
 import { adminSeriesRoutes } from './routes/admin/series.js';
 import { adminTemplateRoutes } from './routes/admin/templates.js';
 import { adminUniversityRoutes } from './routes/admin/universities.js';
+import { adminUserRoutes } from './routes/admin/users.js';
 import { commentRoutes } from './routes/comments.js';
 import { editionProtectedRoutes } from './routes/edition-protected.js';
 import { editionRoutes } from './routes/editions.js';
@@ -93,6 +94,7 @@ export const createApp = (): OpenAPIHono => {
   app.route('/api/admin', adminParticipationRoutes);
   app.route('/api/admin', adminTemplateRoutes);
   app.route('/api/admin', adminUniversityRoutes);
+  app.route('/api/admin', adminUserRoutes);
 
   return app;
 };

--- a/apps/backend/src/routes/admin/users.ts
+++ b/apps/backend/src/routes/admin/users.ts
@@ -56,6 +56,15 @@ const updateMembershipRoleBodySchema = z.object({
   role: z.enum(['owner', 'member']),
 });
 
+const isMemberUniqueViolation = (error: unknown): boolean => {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const pgError = error as { code?: unknown; constraint?: unknown };
+  return pgError.code === '23505' && pgError.constraint === 'member_org_user_unique';
+};
+
 const listUsersRoute = createRoute({
   method: 'get',
   path: '/users',
@@ -370,17 +379,24 @@ adminUserRoutes.openapi(createUserMembershipRoute, async (c) => {
     return c.json({ error: 'Membership already exists' as const }, 409);
   }
 
-  const inserted = await db
-    .insert(members)
-    .values({
-      id: randomUUID(),
-      userId,
-      organizationId: body.data.organizationId,
-      role: body.data.role,
-    })
-    .returning();
+  try {
+    const inserted = await db
+      .insert(members)
+      .values({
+        id: randomUUID(),
+        userId,
+        organizationId: body.data.organizationId,
+        role: body.data.role,
+      })
+      .returning();
 
-  return c.json({ data: inserted[0] }, 201);
+    return c.json({ data: inserted[0] }, 201);
+  } catch (error) {
+    if (isMemberUniqueViolation(error)) {
+      return c.json({ error: 'Membership already exists' as const }, 409);
+    }
+    throw error;
+  }
 });
 
 adminUserRoutes.openapi(updateMembershipRoleRoute, async (c) => {

--- a/apps/backend/src/routes/admin/users.ts
+++ b/apps/backend/src/routes/admin/users.ts
@@ -1,0 +1,428 @@
+import { randomUUID } from 'node:crypto';
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import { and, asc, count, desc, eq, ilike, or } from 'drizzle-orm';
+import { db } from '../../db/index.js';
+import { members, organizations, users } from '../../db/schema.js';
+import {
+  createPaginatedResponseSchema,
+  createPaginationMeta,
+  createPagingQuerySchema,
+  parsePagingParams,
+} from '../../lib/pagination.js';
+import type { AppVariables } from '../../middleware/auth.js';
+import { getMemberById, isLastOwner } from '../../services/membership-management.js';
+
+const userListItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+  isAdmin: z.boolean(),
+  createdAt: z.any(),
+  organizationCount: z.number(),
+});
+
+const membershipSchema = z.object({
+  memberId: z.string(),
+  organizationId: z.string(),
+  organizationName: z.string(),
+  organizationSlug: z.string(),
+  role: z.enum(['owner', 'member']),
+  createdAt: z.any(),
+});
+
+const createdMembershipSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  organizationId: z.string(),
+  role: z.enum(['owner', 'member']),
+  createdAt: z.any(),
+});
+
+const listUserSortValues = [
+  'name:asc',
+  'name:desc',
+  'email:asc',
+  'email:desc',
+  'createdAt:asc',
+  'createdAt:desc',
+] as const;
+
+const createMembershipBodySchema = z.object({
+  organizationId: z.string().min(1),
+  role: z.enum(['owner', 'member']),
+});
+
+const updateMembershipRoleBodySchema = z.object({
+  role: z.enum(['owner', 'member']),
+});
+
+const listUsersRoute = createRoute({
+  method: 'get',
+  path: '/users',
+  request: {
+    query: createPagingQuerySchema(listUserSortValues, true),
+  },
+  responses: {
+    200: {
+      description: 'ユーザー一覧',
+      content: {
+        'application/json': {
+          schema: createPaginatedResponseSchema(userListItemSchema),
+        },
+      },
+    },
+    400: {
+      description: '不正クエリ',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Invalid query') }),
+        },
+      },
+    },
+    422: {
+      description: '不正ソート',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Invalid sort') }),
+        },
+      },
+    },
+  },
+});
+
+const listUserMembershipsRoute = createRoute({
+  method: 'get',
+  path: '/users/{userId}/memberships',
+  request: {
+    params: z.object({ userId: z.string() }),
+  },
+  responses: {
+    200: {
+      description: 'ユーザー所属一覧',
+      content: {
+        'application/json': {
+          schema: z.object({ data: z.array(membershipSchema) }),
+        },
+      },
+    },
+    404: {
+      description: 'ユーザー未検出',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Not found') }),
+        },
+      },
+    },
+  },
+});
+
+const createUserMembershipRoute = createRoute({
+  method: 'post',
+  path: '/users/{userId}/memberships',
+  request: {
+    params: z.object({ userId: z.string() }),
+    body: {
+      content: {
+        'application/json': {
+          schema: createMembershipBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: '所属作成',
+      content: {
+        'application/json': {
+          schema: z.object({ data: createdMembershipSchema }),
+        },
+      },
+    },
+    400: {
+      description: '不正入力',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.any() }),
+        },
+      },
+    },
+    404: {
+      description: '対象未検出',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Not found') }),
+        },
+      },
+    },
+    409: {
+      description: '重複所属',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Membership already exists') }),
+        },
+      },
+    },
+  },
+});
+
+const updateMembershipRoleRoute = createRoute({
+  method: 'put',
+  path: '/memberships/{memberId}/role',
+  request: {
+    params: z.object({ memberId: z.string() }),
+    body: {
+      content: {
+        'application/json': {
+          schema: updateMembershipRoleBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: '所属ロール更新',
+      content: {
+        'application/json': {
+          schema: z.object({ data: createdMembershipSchema }),
+        },
+      },
+    },
+    400: {
+      description: '不正入力',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.any() }),
+        },
+      },
+    },
+    404: {
+      description: '所属未検出',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Not found') }),
+        },
+      },
+    },
+    409: {
+      description: '最後のowner保護',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Last owner cannot be removed') }),
+        },
+      },
+    },
+  },
+});
+
+const deleteMembershipRoute = createRoute({
+  method: 'delete',
+  path: '/memberships/{memberId}',
+  request: {
+    params: z.object({ memberId: z.string() }),
+  },
+  responses: {
+    204: {
+      description: '所属解除',
+    },
+    404: {
+      description: '所属未検出',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Not found') }),
+        },
+      },
+    },
+    409: {
+      description: '最後のowner保護',
+      content: {
+        'application/json': {
+          schema: z.object({ error: z.literal('Last owner cannot be removed') }),
+        },
+      },
+    },
+  },
+});
+
+export const adminUserRoutes = new OpenAPIHono<{ Variables: AppVariables }>();
+
+adminUserRoutes.openapi(listUsersRoute, async (c) => {
+  const parsed = parsePagingParams({
+    query: c.req.query(),
+    schema: createPagingQuerySchema(listUserSortValues, true),
+    sortValues: listUserSortValues,
+    defaultSort: 'createdAt:desc',
+  });
+  if (!parsed.ok) {
+    if (parsed.status === 400) {
+      return c.json({ error: 'Invalid query' as const }, 400);
+    }
+    return c.json({ error: 'Invalid sort' as const }, 422);
+  }
+
+  const whereClause = parsed.value.q
+    ? or(ilike(users.name, `%${parsed.value.q}%`), ilike(users.email, `%${parsed.value.q}%`))
+    : undefined;
+
+  const totalRows = whereClause
+    ? await db.select({ total: count() }).from(users).where(whereClause)
+    : await db.select({ total: count() }).from(users);
+
+  const sortColumn =
+    parsed.value.sort.field === 'name'
+      ? users.name
+      : parsed.value.sort.field === 'email'
+        ? users.email
+        : users.createdAt;
+  const mainOrder = parsed.value.sort.direction === 'asc' ? asc(sortColumn) : desc(sortColumn);
+
+  const rows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      isAdmin: users.isAdmin,
+      createdAt: users.createdAt,
+      organizationCount: count(members.id),
+    })
+    .from(users)
+    .leftJoin(members, eq(members.userId, users.id))
+    .where(whereClause)
+    .groupBy(users.id, users.name, users.email, users.isAdmin, users.createdAt)
+    .orderBy(mainOrder, asc(users.id))
+    .limit(parsed.value.pageSize)
+    .offset(parsed.value.offset);
+
+  return c.json(
+    {
+      data: rows.map((row) => ({
+        ...row,
+        organizationCount: Number(row.organizationCount ?? 0),
+      })),
+      pagination: createPaginationMeta({
+        page: parsed.value.page,
+        pageSize: parsed.value.pageSize,
+        total: totalRows[0]?.total ?? 0,
+      }),
+    },
+    200,
+  );
+});
+
+adminUserRoutes.openapi(listUserMembershipsRoute, async (c) => {
+  const userId = c.req.param('userId');
+  const userRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!userRows[0]) {
+    return c.json({ error: 'Not found' as const }, 404);
+  }
+
+  const rows = await db
+    .select({
+      memberId: members.id,
+      organizationId: members.organizationId,
+      organizationName: organizations.name,
+      organizationSlug: organizations.slug,
+      role: members.role,
+      createdAt: members.createdAt,
+    })
+    .from(members)
+    .innerJoin(organizations, eq(organizations.id, members.organizationId))
+    .where(eq(members.userId, userId))
+    .orderBy(asc(organizations.name), asc(members.id));
+
+  return c.json({ data: rows }, 200);
+});
+
+adminUserRoutes.openapi(createUserMembershipRoute, async (c) => {
+  const userId = c.req.param('userId');
+  const body = createMembershipBodySchema.safeParse(await c.req.json());
+  if (!body.success) {
+    return c.json({ error: body.error.flatten() }, 400);
+  }
+
+  const userRows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!userRows[0]) {
+    return c.json({ error: 'Not found' as const }, 404);
+  }
+
+  const organizationRows = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.id, body.data.organizationId))
+    .limit(1);
+  if (!organizationRows[0]) {
+    return c.json({ error: 'Not found' as const }, 404);
+  }
+
+  const existing = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(and(eq(members.userId, userId), eq(members.organizationId, body.data.organizationId)))
+    .limit(1);
+  if (existing[0]) {
+    return c.json({ error: 'Membership already exists' as const }, 409);
+  }
+
+  const inserted = await db
+    .insert(members)
+    .values({
+      id: randomUUID(),
+      userId,
+      organizationId: body.data.organizationId,
+      role: body.data.role,
+    })
+    .returning();
+
+  return c.json({ data: inserted[0] }, 201);
+});
+
+adminUserRoutes.openapi(updateMembershipRoleRoute, async (c) => {
+  const memberId = c.req.param('memberId');
+  const body = updateMembershipRoleBodySchema.safeParse(await c.req.json());
+  if (!body.success) {
+    return c.json({ error: body.error.flatten() }, 400);
+  }
+
+  const targetMember = await getMemberById(memberId);
+  if (!targetMember) {
+    return c.json({ error: 'Not found' as const }, 404);
+  }
+
+  if (
+    targetMember.role === 'owner' &&
+    body.data.role !== 'owner' &&
+    (await isLastOwner(targetMember.organizationId))
+  ) {
+    return c.json({ error: 'Last owner cannot be removed' as const }, 409);
+  }
+
+  const updated = await db
+    .update(members)
+    .set({ role: body.data.role })
+    .where(eq(members.id, memberId))
+    .returning();
+
+  return c.json({ data: updated[0] }, 200);
+});
+
+adminUserRoutes.openapi(deleteMembershipRoute, async (c) => {
+  const memberId = c.req.param('memberId');
+  const targetMember = await getMemberById(memberId);
+  if (!targetMember) {
+    return c.json({ error: 'Not found' as const }, 404);
+  }
+
+  if (targetMember.role === 'owner' && (await isLastOwner(targetMember.organizationId))) {
+    return c.json({ error: 'Last owner cannot be removed' as const }, 409);
+  }
+
+  await db.delete(members).where(eq(members.id, memberId));
+  return c.body(null, 204);
+});

--- a/apps/backend/src/routes/university.ts
+++ b/apps/backend/src/routes/university.ts
@@ -11,6 +11,7 @@ import {
 } from '../lib/pagination.js';
 import type { AppVariables } from '../middleware/auth.js';
 import { emailService } from '../services/email/index.js';
+import { getScopedMember, isLastOwner } from '../services/membership-management.js';
 
 const inviteSchema = z.object({
   email: z.string().email(),
@@ -266,25 +267,6 @@ const canManageMembers = async (userId: string, organizationId: string): Promise
     .limit(1);
 
   return ownerRows[0]?.role === 'owner';
-};
-
-const getScopedMember = async (memberId: string, organizationId: string) => {
-  const rows = await db
-    .select({ id: members.id, role: members.role })
-    .from(members)
-    .where(and(eq(members.id, memberId), eq(members.organizationId, organizationId)))
-    .limit(1);
-
-  return rows[0] ?? null;
-};
-
-const isLastOwner = async (organizationId: string): Promise<boolean> => {
-  const rows = await db
-    .select({ total: count() })
-    .from(members)
-    .where(and(eq(members.organizationId, organizationId), eq(members.role, 'owner')));
-
-  return (rows[0]?.total ?? 0) <= 1;
 };
 
 universityRoutes.openapi(listUniversityMembersRoute, async (c) => {

--- a/apps/backend/src/services/membership-management.ts
+++ b/apps/backend/src/services/membership-management.ts
@@ -1,0 +1,52 @@
+import { and, count, eq } from 'drizzle-orm';
+import { db } from '../db/index.js';
+import { members } from '../db/schema.js';
+
+export type ScopedMember = {
+  id: string;
+  userId: string;
+  organizationId: string;
+  role: 'owner' | 'member';
+};
+
+export const getScopedMember = async (
+  memberId: string,
+  organizationId: string,
+): Promise<ScopedMember | null> => {
+  const rows = await db
+    .select({
+      id: members.id,
+      userId: members.userId,
+      organizationId: members.organizationId,
+      role: members.role,
+    })
+    .from(members)
+    .where(and(eq(members.id, memberId), eq(members.organizationId, organizationId)))
+    .limit(1);
+
+  return rows[0] ?? null;
+};
+
+export const getMemberById = async (memberId: string): Promise<ScopedMember | null> => {
+  const rows = await db
+    .select({
+      id: members.id,
+      userId: members.userId,
+      organizationId: members.organizationId,
+      role: members.role,
+    })
+    .from(members)
+    .where(eq(members.id, memberId))
+    .limit(1);
+
+  return rows[0] ?? null;
+};
+
+export const isLastOwner = async (organizationId: string): Promise<boolean> => {
+  const rows = await db
+    .select({ total: count() })
+    .from(members)
+    .where(and(eq(members.organizationId, organizationId), eq(members.role, 'owner')));
+
+  return (rows[0]?.total ?? 0) <= 1;
+};

--- a/apps/frontend/app/(admin)/admin/page.tsx
+++ b/apps/frontend/app/(admin)/admin/page.tsx
@@ -17,6 +17,11 @@ const adminSections = [
     title: '大学管理',
     description: '大学の作成・代表者招待',
   },
+  {
+    href: '/admin/users',
+    title: 'ユーザー管理',
+    description: 'ユーザー所属の追加・ロール変更・所属解除',
+  },
 ];
 
 export default function AdminDashboardPage() {

--- a/apps/frontend/app/(admin)/admin/users/page.tsx
+++ b/apps/frontend/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import { type UniversityOption, UniversitySelect } from '@/components/admin/UniversitySelect';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { DataTable } from '@/components/common/DataTable';
+import { DateTimeDisplay } from '@/components/common/DateTimeDisplay';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { ROLE_LABELS } from '@/lib/utils/status';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { ColumnDef } from '@tanstack/react-table';
+import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  isAdmin: boolean;
+  createdAt: unknown;
+  organizationCount: number;
+};
+
+type Membership = {
+  memberId: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  role: 'owner' | 'member';
+  createdAt: unknown;
+};
+
+const listParsers = {
+  page: parseAsInteger.withDefault(1),
+  pageSize: parseAsInteger.withDefault(20),
+  q: parseAsString.withDefault(''),
+  sort: parseAsString.withDefault('createdAt:desc'),
+};
+
+function MembershipDialog({
+  user,
+  open,
+  onOpenChange,
+}: {
+  user: AdminUser | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const queryClient = useQueryClient();
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState('');
+  const [selectedRole, setSelectedRole] = useState<'owner' | 'member'>('member');
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedOrganizationId('');
+      setSelectedRole('member');
+    }
+  }, [open]);
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.admin.userMemberships(user?.id ?? ''),
+    queryFn: async () => {
+      if (!user) {
+        return null;
+      }
+      const result = await apiClient.GET('/api/admin/users/{userId}/memberships', {
+        params: { path: { userId: user.id } },
+      });
+      return throwIfError(result);
+    },
+    enabled: open && !!user,
+  });
+
+  const invalidateTargets = async () => {
+    if (!user) {
+      return;
+    }
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.userMemberships(user.id) }),
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] }),
+    ]);
+  };
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      if (!user || !selectedOrganizationId) {
+        return;
+      }
+      const result = await apiClient.POST('/api/admin/users/{userId}/memberships', {
+        params: { path: { userId: user.id } },
+        body: {
+          organizationId: selectedOrganizationId,
+          role: selectedRole,
+        },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      toast.success('所属を追加しました');
+      setSelectedOrganizationId('');
+      setSelectedRole('member');
+      await invalidateTargets();
+    },
+    onError: (error) => {
+      const message =
+        error instanceof ApiError && error.status === 409
+          ? getApiErrorMessage(error, 'duplicate')
+          : getApiErrorMessage(error);
+      toast.error(message);
+    },
+  });
+
+  const changeRoleMutation = useMutation({
+    mutationFn: async ({ memberId, role }: { memberId: string; role: 'owner' | 'member' }) => {
+      const result = await apiClient.PUT('/api/admin/memberships/{memberId}/role', {
+        params: { path: { memberId } },
+        body: { role },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      toast.success('ロールを更新しました');
+      await invalidateTargets();
+    },
+    onError: (error) => {
+      const message =
+        error instanceof ApiError && error.status === 409
+          ? getApiErrorMessage(error, 'last-owner')
+          : getApiErrorMessage(error);
+      toast.error(message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (memberId: string) => {
+      const result = await apiClient.DELETE('/api/admin/memberships/{memberId}', {
+        params: { path: { memberId } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      toast.success('所属を解除しました');
+      await invalidateTargets();
+    },
+    onError: (error) => {
+      const message =
+        error instanceof ApiError && error.status === 409
+          ? getApiErrorMessage(error, 'last-owner')
+          : getApiErrorMessage(error);
+      toast.error(message);
+    },
+  });
+
+  const memberships = (data?.data ?? []) as Membership[];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-2xl'>
+        <DialogHeader>
+          <DialogTitle>所属管理: {user?.name ?? ''}</DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-3 rounded-md border p-3'>
+          <p className='text-sm font-medium'>大学へ所属させる</p>
+          <div className='flex flex-wrap gap-2'>
+            <UniversitySelect
+              value={selectedOrganizationId}
+              onValueChange={(id: string, university: UniversityOption | null) => {
+                setSelectedOrganizationId(university?.id ?? id);
+              }}
+              placeholder='大学を選択'
+              disabled={createMutation.isPending}
+            />
+            <Select
+              value={selectedRole}
+              onValueChange={(value) => setSelectedRole(value as 'owner' | 'member')}
+            >
+              <SelectTrigger className='w-32'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='member'>メンバー</SelectItem>
+                <SelectItem value='owner'>オーナー</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              onClick={() => createMutation.mutate()}
+              disabled={!selectedOrganizationId || createMutation.isPending}
+            >
+              所属追加
+            </Button>
+          </div>
+        </div>
+
+        <div className='space-y-2'>
+          <p className='text-sm font-medium'>現在の所属</p>
+          {isLoading ? (
+            <p className='text-sm text-muted-foreground'>読み込み中...</p>
+          ) : memberships.length === 0 ? (
+            <p className='text-sm text-muted-foreground'>所属がありません</p>
+          ) : (
+            <div className='space-y-2'>
+              {memberships.map((membership) => (
+                <div
+                  key={membership.memberId}
+                  className='flex flex-wrap items-center justify-between gap-2 rounded-md border p-3'
+                >
+                  <div>
+                    <p className='font-medium'>{membership.organizationName}</p>
+                    <p className='text-xs text-muted-foreground'>
+                      slug: {membership.organizationSlug}
+                    </p>
+                  </div>
+                  <div className='flex items-center gap-2'>
+                    <Select
+                      value={membership.role}
+                      onValueChange={(value) =>
+                        changeRoleMutation.mutate({
+                          memberId: membership.memberId,
+                          role: value as 'owner' | 'member',
+                        })
+                      }
+                    >
+                      <SelectTrigger className='w-32'>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value='owner'>オーナー</SelectItem>
+                        <SelectItem value='member'>メンバー</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <ConfirmDialog
+                      trigger={
+                        <Button
+                          size='sm'
+                          variant='ghost'
+                          className='text-destructive hover:text-destructive'
+                        >
+                          解除
+                        </Button>
+                      }
+                      title='所属を解除しますか？'
+                      description={`${membership.organizationName} から解除します。`}
+                      confirmLabel='解除'
+                      onConfirm={() => deleteMutation.mutate(membership.memberId)}
+                      destructive
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function AdminUsersPage() {
+  const [queryParams, setQueryParams] = useQueryStates(listParsers);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.admin.users(queryParams),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/admin/users', {
+        params: {
+          query: {
+            page: queryParams.page,
+            pageSize: queryParams.pageSize,
+            q: queryParams.q || undefined,
+            sort: queryParams.sort as
+              | 'name:asc'
+              | 'name:desc'
+              | 'email:asc'
+              | 'email:desc'
+              | 'createdAt:asc'
+              | 'createdAt:desc',
+          },
+        },
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const sortOptions = useMemo(
+    () => [
+      { value: 'createdAt:desc', label: '作成日 新しい順' },
+      { value: 'createdAt:asc', label: '作成日 古い順' },
+      { value: 'name:asc', label: '名前 昇順' },
+      { value: 'name:desc', label: '名前 降順' },
+      { value: 'email:asc', label: 'メール 昇順' },
+      { value: 'email:desc', label: 'メール 降順' },
+    ],
+    [],
+  );
+
+  const columns: ColumnDef<AdminUser>[] = [
+    {
+      header: 'ユーザー',
+      cell: ({ row }) => (
+        <div>
+          <p className='font-medium'>{row.original.name}</p>
+          <p className='text-xs text-muted-foreground'>{row.original.email}</p>
+        </div>
+      ),
+    },
+    {
+      header: '権限',
+      cell: ({ row }) =>
+        row.original.isAdmin ? <Badge>Admin</Badge> : <Badge variant='secondary'>User</Badge>,
+    },
+    {
+      header: '所属数',
+      cell: ({ row }) => <span>{row.original.organizationCount}</span>,
+    },
+    {
+      header: '作成日',
+      cell: ({ row }) => <DateTimeDisplay value={String(row.original.createdAt)} dateOnly />,
+    },
+    {
+      header: '',
+      id: 'actions',
+      cell: ({ row }) => (
+        <Button
+          size='sm'
+          variant='outline'
+          onClick={() => {
+            setSelectedUser(row.original);
+            setDialogOpen(true);
+          }}
+        >
+          所属管理
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <div className='space-y-4'>
+      <div className='flex items-center justify-between gap-3 flex-wrap'>
+        <h1 className='text-2xl font-bold'>ユーザー管理</h1>
+        <div className='flex gap-2 flex-wrap'>
+          <Input
+            placeholder='名前・メールで検索...'
+            defaultValue={queryParams.q}
+            onChange={(e) => setQueryParams({ q: e.target.value, page: 1 })}
+            className='max-w-56'
+          />
+          <Select
+            value={queryParams.sort}
+            onValueChange={(value) => setQueryParams({ sort: value })}
+          >
+            <SelectTrigger className='w-48'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {sortOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={(data?.data ?? []) as AdminUser[]}
+        isLoading={isLoading}
+        pagination={data?.pagination}
+        onPageChange={(page) => setQueryParams({ page })}
+        onPageSizeChange={(pageSize) => setQueryParams({ pageSize, page: 1 })}
+      />
+
+      <MembershipDialog user={selectedUser} open={dialogOpen} onOpenChange={setDialogOpen} />
+    </div>
+  );
+}

--- a/apps/frontend/app/(admin)/layout.tsx
+++ b/apps/frontend/app/(admin)/layout.tsx
@@ -12,6 +12,7 @@ const adminNavLinks = [
   { href: '/admin/series', label: '大会シリーズ' },
   { href: '/admin/editions', label: '大会回' },
   { href: '/admin/universities', label: '大学' },
+  { href: '/admin/users', label: 'ユーザー管理' },
 ];
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {

--- a/apps/frontend/components/layout/OrgSwitcher.tsx
+++ b/apps/frontend/components/layout/OrgSwitcher.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -13,7 +14,6 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useOrganization } from '@/contexts/OrganizationContext';
 import { Building2Icon, ChevronDownIcon } from 'lucide-react';
 
-// We need a dropdown menu component - install it
 export function OrgSwitcher() {
   const { organizations } = useAuth();
   const { organizationId, setOrganizationId, currentOrg } = useOrganization();
@@ -44,7 +44,9 @@ export function OrgSwitcher() {
         <ChevronDownIcon className='h-3 w-3' />
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>
-        <DropdownMenuLabel>大学を切り替え</DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>大学を切り替え</DropdownMenuLabel>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         {organizations.map((org) => (
           <DropdownMenuItem

--- a/apps/frontend/lib/api/schema.ts
+++ b/apps/frontend/lib/api/schema.ts
@@ -3800,6 +3800,373 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/admin/users': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          pageSize?: number;
+          sort?:
+            | 'name:asc'
+            | 'name:desc'
+            | 'email:asc'
+            | 'email:desc'
+            | 'createdAt:asc'
+            | 'createdAt:desc';
+          q?: string;
+        };
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description ユーザー一覧 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: {
+                id: string;
+                name: string;
+                /** Format: email */
+                email: string;
+                isAdmin: boolean;
+                createdAt?: unknown;
+                organizationCount: number;
+              }[];
+              pagination: {
+                page: number;
+                pageSize: number;
+                total: number;
+                totalPages: number;
+                hasNext: boolean;
+                hasPrev: boolean;
+              };
+            };
+          };
+        };
+        /** @description 不正クエリ */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Invalid query';
+            };
+          };
+        };
+        /** @description 不正ソート */
+        422: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Invalid sort';
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/admin/users/{userId}/memberships': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description ユーザー所属一覧 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: {
+                memberId: string;
+                organizationId: string;
+                organizationName: string;
+                organizationSlug: string;
+                /** @enum {string} */
+                role: 'owner' | 'member';
+                createdAt?: unknown;
+              }[];
+            };
+          };
+        };
+        /** @description ユーザー未検出 */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Not found';
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          userId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            organizationId: string;
+            /** @enum {string} */
+            role: 'owner' | 'member';
+          };
+        };
+      };
+      responses: {
+        /** @description 所属作成 */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: {
+                id: string;
+                userId: string;
+                organizationId: string;
+                /** @enum {string} */
+                role: 'owner' | 'member';
+                createdAt?: unknown;
+              };
+            };
+          };
+        };
+        /** @description 不正入力 */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error?: unknown;
+            };
+          };
+        };
+        /** @description 対象未検出 */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Not found';
+            };
+          };
+        };
+        /** @description 重複所属 */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Membership already exists';
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/admin/memberships/{memberId}/role': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          memberId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': {
+            /** @enum {string} */
+            role: 'owner' | 'member';
+          };
+        };
+      };
+      responses: {
+        /** @description 所属ロール更新 */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              data: {
+                id: string;
+                userId: string;
+                organizationId: string;
+                /** @enum {string} */
+                role: 'owner' | 'member';
+                createdAt?: unknown;
+              };
+            };
+          };
+        };
+        /** @description 不正入力 */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              error?: unknown;
+            };
+          };
+        };
+        /** @description 所属未検出 */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Not found';
+            };
+          };
+        };
+        /** @description 最後のowner保護 */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Last owner cannot be removed';
+            };
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/admin/memberships/{memberId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          memberId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description 所属解除 */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description 所属未検出 */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Not found';
+            };
+          };
+        };
+        /** @description 最後のowner保護 */
+        409: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              /** @enum {string} */
+              error: 'Last owner cannot be removed';
+            };
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/apps/frontend/lib/query/keys.ts
+++ b/apps/frontend/lib/query/keys.ts
@@ -52,5 +52,7 @@ export const queryKeys = {
     templates: (editionId: string, params: Record<string, unknown>) =>
       ['admin', 'editions', editionId, 'templates', params] as const,
     universities: (params: Record<string, unknown>) => ['admin', 'universities', params] as const,
+    users: (params: Record<string, unknown>) => ['admin', 'users', params] as const,
+    userMemberships: (userId: string) => ['admin', 'users', userId, 'memberships'] as const,
   },
 };

--- a/apps/frontend/openapi.json
+++ b/apps/frontend/openapi.json
@@ -1,13 +1,7 @@
 {
   "openapi": "3.0.0",
-  "info": {
-    "title": "Robocon Docshare API",
-    "version": "0.1.0"
-  },
-  "components": {
-    "schemas": {},
-    "parameters": {}
-  },
+  "info": { "title": "Robocon Docshare API", "version": "0.1.0" },
+  "components": { "schemas": {}, "parameters": {} },
   "paths": {
     "/api/health": {
       "get": {
@@ -18,12 +12,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "enum": [true]
-                    }
-                  },
+                  "properties": { "ok": { "type": "boolean", "enum": [true] } },
                   "required": ["ok"]
                 }
               }
@@ -36,22 +25,13 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -68,10 +48,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -90,40 +67,23 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true
-                          },
+                          "id": { "type": "string", "format": "uuid" },
+                          "name": { "type": "string" },
+                          "description": { "type": "string", "nullable": true },
                           "externalLinks": {
                             "type": "array",
                             "nullable": true,
                             "items": {
                               "type": "object",
                               "properties": {
-                                "label": {
-                                  "type": "string"
-                                },
-                                "url": {
-                                  "type": "string",
-                                  "format": "uri"
-                                }
+                                "label": { "type": "string" },
+                                "url": { "type": "string", "format": "uri" }
                               },
                               "required": ["label", "url"]
                             }
                           },
-                          "createdAt": {
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          }
+                          "createdAt": { "nullable": true },
+                          "updatedAt": { "nullable": true }
                         },
                         "required": ["id", "name", "description", "externalLinks"]
                       }
@@ -131,29 +91,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -169,12 +112,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -186,12 +124,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -204,10 +137,7 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -224,40 +154,23 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "externalLinks": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": ["id", "name", "description", "externalLinks"]
                     }
@@ -273,12 +186,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -291,22 +199,13 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -330,19 +229,13 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": false,
             "name": "series_id",
             "in": "query"
@@ -361,43 +254,21 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "seriesId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "year": {
-                            "type": "integer"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true
-                          },
+                          "id": { "type": "string", "format": "uuid" },
+                          "seriesId": { "type": "string", "format": "uuid" },
+                          "year": { "type": "integer" },
+                          "name": { "type": "string" },
+                          "description": { "type": "string", "nullable": true },
                           "ruleDocuments": {
                             "type": "array",
                             "nullable": true,
                             "items": {
                               "type": "object",
                               "properties": {
-                                "label": {
-                                  "type": "string"
-                                },
-                                "s3_key": {
-                                  "type": "string"
-                                },
-                                "mime_type": {
-                                  "type": "string"
-                                },
-                                "url": {
-                                  "type": "string",
-                                  "format": "uri"
-                                }
+                                "label": { "type": "string" },
+                                "s3_key": { "type": "string" },
+                                "mime_type": { "type": "string" },
+                                "url": { "type": "string", "format": "uri" }
                               },
                               "required": ["label", "s3_key", "mime_type", "url"]
                             }
@@ -412,23 +283,14 @@
                             "items": {
                               "type": "object",
                               "properties": {
-                                "label": {
-                                  "type": "string"
-                                },
-                                "url": {
-                                  "type": "string",
-                                  "format": "uri"
-                                }
+                                "label": { "type": "string" },
+                                "url": { "type": "string", "format": "uri" }
                               },
                               "required": ["label", "url"]
                             }
                           },
-                          "createdAt": {
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          }
+                          "createdAt": { "nullable": true },
+                          "updatedAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -445,29 +307,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -483,12 +328,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -500,12 +340,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -518,10 +353,7 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -538,43 +370,21 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "seriesId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "year": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "seriesId": { "type": "string", "format": "uuid" },
+                        "year": { "type": "integer" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "ruleDocuments": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "s3_key": {
-                                "type": "string"
-                              },
-                              "mime_type": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "s3_key": { "type": "string" },
+                              "mime_type": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "s3_key", "mime_type", "url"]
                           }
@@ -589,23 +399,14 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -630,12 +431,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -660,19 +456,10 @@
                         "user": {
                           "type": "object",
                           "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "email": {
-                              "type": "string",
-                              "format": "email"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "isAdmin": {
-                              "type": "boolean"
-                            }
+                            "id": { "type": "string" },
+                            "email": { "type": "string", "format": "email" },
+                            "name": { "type": "string" },
+                            "isAdmin": { "type": "boolean" }
                           },
                           "required": ["id", "email", "name", "isAdmin"]
                         },
@@ -681,27 +468,15 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "slug": {
-                                "type": "string"
-                              },
-                              "role": {
-                                "type": "string",
-                                "enum": ["owner", "member"]
-                              }
+                              "id": { "type": "string" },
+                              "name": { "type": "string" },
+                              "slug": { "type": "string" },
+                              "role": { "type": "string", "enum": ["owner", "member"] }
                             },
                             "required": ["id", "name", "slug", "role"]
                           }
                         },
-                        "activeOrganizationId": {
-                          "type": "string",
-                          "nullable": true
-                        }
+                        "activeOrganizationId": { "type": "string", "nullable": true }
                       },
                       "required": ["user", "organizations", "activeOrganizationId"]
                     }
@@ -717,12 +492,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Unauthorized"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Unauthorized"] } },
                   "required": ["error"]
                 }
               }
@@ -735,31 +505,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -783,10 +541,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -805,48 +560,21 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "editionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "acceptType": {
-                            "type": "string",
-                            "enum": ["file", "url"]
-                          },
+                          "id": { "type": "string", "format": "uuid" },
+                          "editionId": { "type": "string", "format": "uuid" },
+                          "name": { "type": "string" },
+                          "description": { "type": "string", "nullable": true },
+                          "acceptType": { "type": "string", "enum": ["file", "url"] },
                           "allowedExtensions": {
                             "type": "array",
                             "nullable": true,
-                            "items": {
-                              "type": "string"
-                            }
+                            "items": { "type": "string" }
                           },
-                          "urlPattern": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "maxFileSizeMb": {
-                            "type": "integer"
-                          },
-                          "isRequired": {
-                            "type": "boolean"
-                          },
-                          "sortOrder": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          }
+                          "urlPattern": { "type": "string", "nullable": true },
+                          "maxFileSizeMb": { "type": "integer" },
+                          "isRequired": { "type": "boolean" },
+                          "sortOrder": { "type": "integer" },
+                          "createdAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -865,29 +593,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -903,12 +614,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -920,12 +626,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -938,31 +639,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -979,10 +668,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -1001,46 +687,17 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "templateId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "participationId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "submittedBy": {
-                            "type": "string"
-                          },
-                          "version": {
-                            "type": "integer"
-                          },
-                          "fileName": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "fileSizeBytes": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "fileMimeType": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "url": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          }
+                          "id": { "type": "string", "format": "uuid" },
+                          "templateId": { "type": "string", "format": "uuid" },
+                          "participationId": { "type": "string", "format": "uuid" },
+                          "submittedBy": { "type": "string" },
+                          "version": { "type": "integer" },
+                          "fileName": { "type": "string", "nullable": true },
+                          "fileSizeBytes": { "type": "number", "nullable": true },
+                          "fileMimeType": { "type": "string", "nullable": true },
+                          "url": { "type": "string", "nullable": true },
+                          "createdAt": { "nullable": true },
+                          "updatedAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -1055,35 +712,16 @@
                         ]
                       }
                     },
-                    "organizationId": {
-                      "type": "string"
-                    },
+                    "organizationId": { "type": "string" },
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -1102,14 +740,8 @@
                   "properties": {
                     "error": {
                       "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": ["Invalid query"]
-                        },
-                        {
-                          "type": "string",
-                          "enum": ["x-organization-id is required"]
-                        }
+                        { "type": "string", "enum": ["Invalid query"] },
+                        { "type": "string", "enum": ["x-organization-id is required"] }
                       ]
                     }
                   },
@@ -1124,12 +756,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -1142,10 +769,7 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -1164,27 +788,12 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "editionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "universityId": {
-                            "type": "string"
-                          },
-                          "universityName": {
-                            "type": "string"
-                          },
-                          "teamName": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          }
+                          "id": { "type": "string", "format": "uuid" },
+                          "editionId": { "type": "string", "format": "uuid" },
+                          "universityId": { "type": "string" },
+                          "universityName": { "type": "string" },
+                          "teamName": { "type": "string", "nullable": true },
+                          "createdAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -1208,10 +817,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["x-organization-id is required"]
-                    }
+                    "error": { "type": "string", "enum": ["x-organization-id is required"] }
                   },
                   "required": ["error"]
                 }
@@ -1225,10 +831,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid organization context"]
-                    }
+                    "error": { "type": "string", "enum": ["Invalid organization context"] }
                   },
                   "required": ["error"]
                 }
@@ -1242,10 +845,7 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -1265,10 +865,7 @@
                         "edition": {
                           "type": "object",
                           "properties": {
-                            "id": {
-                              "type": "string",
-                              "format": "uuid"
-                            },
+                            "id": { "type": "string", "format": "uuid" },
                             "sharingStatus": {
                               "type": "string",
                               "enum": ["draft", "accepting", "sharing", "closed"]
@@ -1281,14 +878,8 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "teamName": {
-                                "type": "string",
-                                "nullable": true
-                              }
+                              "id": { "type": "string", "format": "uuid" },
+                              "teamName": { "type": "string", "nullable": true }
                             },
                             "required": ["id", "teamName"]
                           }
@@ -1298,37 +889,18 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "acceptType": {
-                                "type": "string",
-                                "enum": ["file", "url"]
-                              },
-                              "isRequired": {
-                                "type": "boolean"
-                              },
+                              "id": { "type": "string", "format": "uuid" },
+                              "name": { "type": "string" },
+                              "acceptType": { "type": "string", "enum": ["file", "url"] },
+                              "isRequired": { "type": "boolean" },
                               "allowedExtensions": {
                                 "type": "array",
                                 "nullable": true,
-                                "items": {
-                                  "type": "string"
-                                }
+                                "items": { "type": "string" }
                               },
-                              "urlPattern": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "maxFileSizeMb": {
-                                "type": "integer"
-                              },
-                              "sortOrder": {
-                                "type": "integer"
-                              }
+                              "urlPattern": { "type": "string", "nullable": true },
+                              "maxFileSizeMb": { "type": "integer" },
+                              "sortOrder": { "type": "integer" }
                             },
                             "required": [
                               "id",
@@ -1347,36 +919,17 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "participationId": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "templateId": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
+                              "participationId": { "type": "string", "format": "uuid" },
+                              "templateId": { "type": "string", "format": "uuid" },
                               "submission": {
                                 "type": "object",
                                 "nullable": true,
                                 "properties": {
-                                  "id": {
-                                    "type": "string",
-                                    "format": "uuid"
-                                  },
-                                  "version": {
-                                    "type": "integer"
-                                  },
-                                  "fileName": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "url": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "updatedAt": {
-                                    "nullable": true
-                                  }
+                                  "id": { "type": "string", "format": "uuid" },
+                                  "version": { "type": "integer" },
+                                  "fileName": { "type": "string", "nullable": true },
+                                  "url": { "type": "string", "nullable": true },
+                                  "updatedAt": { "nullable": true }
                                 },
                                 "required": ["id", "version", "fileName", "url"]
                               }
@@ -1400,10 +953,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["x-organization-id is required"]
-                    }
+                    "error": { "type": "string", "enum": ["x-organization-id is required"] }
                   },
                   "required": ["error"]
                 }
@@ -1417,10 +967,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid organization context"]
-                    }
+                    "error": { "type": "string", "enum": ["Invalid organization context"] }
                   },
                   "required": ["error"]
                 }
@@ -1433,12 +980,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -1451,10 +993,7 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -1471,27 +1010,12 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "universityId": {
-                          "type": "string"
-                        },
-                        "universityName": {
-                          "type": "string"
-                        },
-                        "teamName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "universityId": { "type": "string" },
+                        "universityName": { "type": "string" },
+                        "teamName": { "type": "string", "nullable": true },
+                        "createdAt": { "nullable": true }
                       },
                       "required": ["id", "editionId", "universityId", "universityName", "teamName"]
                     }
@@ -1507,12 +1031,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -1524,12 +1043,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -1542,31 +1056,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -1596,41 +1098,20 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
+                          "id": { "type": "string", "format": "uuid" },
                           "template": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "acceptType": {
-                                "type": "string",
-                                "enum": ["file", "url"]
-                              }
+                              "id": { "type": "string", "format": "uuid" },
+                              "name": { "type": "string" },
+                              "acceptType": { "type": "string", "enum": ["file", "url"] }
                             },
                             "required": ["id", "name", "acceptType"]
                           },
-                          "version": {
-                            "type": "integer"
-                          },
-                          "fileName": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "url": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          }
+                          "version": { "type": "integer" },
+                          "fileName": { "type": "string", "nullable": true },
+                          "url": { "type": "string", "nullable": true },
+                          "updatedAt": { "nullable": true }
                         },
                         "required": ["id", "template", "version", "fileName", "url"]
                       }
@@ -1638,29 +1119,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -1676,12 +1140,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -1693,12 +1152,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -1710,12 +1164,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -1727,12 +1176,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -1749,32 +1193,13 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "templateId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "participationId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "s3Key": {
-                    "type": "string"
-                  },
-                  "fileName": {
-                    "type": "string"
-                  },
-                  "fileSizeBytes": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "exclusiveMinimum": true
-                  },
-                  "mimeType": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string",
-                    "format": "uri"
-                  }
+                  "templateId": { "type": "string", "format": "uuid" },
+                  "participationId": { "type": "string", "format": "uuid" },
+                  "s3Key": { "type": "string" },
+                  "fileName": { "type": "string" },
+                  "fileSizeBytes": { "type": "integer", "minimum": 0, "exclusiveMinimum": true },
+                  "mimeType": { "type": "string" },
+                  "url": { "type": "string", "format": "uri" }
                 },
                 "required": ["templateId", "participationId"]
               }
@@ -1792,46 +1217,17 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "templateId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "participationId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "submittedBy": {
-                          "type": "string"
-                        },
-                        "version": {
-                          "type": "integer"
-                        },
-                        "fileName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "fileSizeBytes": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "fileMimeType": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "url": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "templateId": { "type": "string", "format": "uuid" },
+                        "participationId": { "type": "string", "format": "uuid" },
+                        "submittedBy": { "type": "string" },
+                        "version": { "type": "integer" },
+                        "fileName": { "type": "string", "nullable": true },
+                        "fileSizeBytes": { "type": "number", "nullable": true },
+                        "fileMimeType": { "type": "string", "nullable": true },
+                        "url": { "type": "string", "nullable": true },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -1855,14 +1251,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -1872,11 +1261,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
+                  "properties": { "error": { "type": "string" } },
                   "required": ["error"]
                 }
               }
@@ -1888,14 +1273,7 @@
     "/api/submissions/{id}": {
       "put": {
         "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
+          { "schema": { "type": "string" }, "required": true, "name": "id", "in": "path" }
         ],
         "requestBody": {
           "content": {
@@ -1903,24 +1281,11 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "s3Key": {
-                    "type": "string"
-                  },
-                  "fileName": {
-                    "type": "string"
-                  },
-                  "fileSizeBytes": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "exclusiveMinimum": true
-                  },
-                  "mimeType": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string",
-                    "format": "uri"
-                  }
+                  "s3Key": { "type": "string" },
+                  "fileName": { "type": "string" },
+                  "fileSizeBytes": { "type": "integer", "minimum": 0, "exclusiveMinimum": true },
+                  "mimeType": { "type": "string" },
+                  "url": { "type": "string", "format": "uri" }
                 }
               }
             }
@@ -1937,46 +1302,17 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "templateId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "participationId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "submittedBy": {
-                          "type": "string"
-                        },
-                        "version": {
-                          "type": "integer"
-                        },
-                        "fileName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "fileSizeBytes": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "fileMimeType": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "url": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "templateId": { "type": "string", "format": "uuid" },
+                        "participationId": { "type": "string", "format": "uuid" },
+                        "submittedBy": { "type": "string" },
+                        "version": { "type": "integer" },
+                        "fileName": { "type": "string", "nullable": true },
+                        "fileSizeBytes": { "type": "number", "nullable": true },
+                        "fileMimeType": { "type": "string", "nullable": true },
+                        "url": { "type": "string", "nullable": true },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -2000,14 +1336,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -2017,12 +1346,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -2049,31 +1373,17 @@
       },
       "delete": {
         "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
+          { "schema": { "type": "string" }, "required": true, "name": "id", "in": "path" }
         ],
         "responses": {
-          "204": {
-            "description": "提出削除"
-          },
+          "204": { "description": "提出削除" },
           "403": {
             "description": "権限なし",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -2086,31 +1396,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -2134,10 +1432,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -2159,46 +1454,17 @@
                           "submission": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "templateId": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "participationId": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "submittedBy": {
-                                "type": "string"
-                              },
-                              "version": {
-                                "type": "integer"
-                              },
-                              "fileName": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "fileSizeBytes": {
-                                "type": "number",
-                                "nullable": true
-                              },
-                              "fileMimeType": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "url": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "createdAt": {
-                                "nullable": true
-                              },
-                              "updatedAt": {
-                                "nullable": true
-                              }
+                              "id": { "type": "string", "format": "uuid" },
+                              "templateId": { "type": "string", "format": "uuid" },
+                              "participationId": { "type": "string", "format": "uuid" },
+                              "submittedBy": { "type": "string" },
+                              "version": { "type": "integer" },
+                              "fileName": { "type": "string", "nullable": true },
+                              "fileSizeBytes": { "type": "number", "nullable": true },
+                              "fileMimeType": { "type": "string", "nullable": true },
+                              "url": { "type": "string", "nullable": true },
+                              "createdAt": { "nullable": true },
+                              "updatedAt": { "nullable": true }
                             },
                             "required": [
                               "id",
@@ -2215,27 +1481,12 @@
                           "participation": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "editionId": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "universityId": {
-                                "type": "string"
-                              },
-                              "universityName": {
-                                "type": "string"
-                              },
-                              "teamName": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "createdAt": {
-                                "nullable": true
-                              }
+                              "id": { "type": "string", "format": "uuid" },
+                              "editionId": { "type": "string", "format": "uuid" },
+                              "universityId": { "type": "string" },
+                              "universityName": { "type": "string" },
+                              "teamName": { "type": "string", "nullable": true },
+                              "createdAt": { "nullable": true }
                             },
                             "required": [
                               "id",
@@ -2252,29 +1503,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -2290,12 +1524,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -2307,12 +1536,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -2324,12 +1548,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -2342,31 +1561,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -2390,10 +1597,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -2412,20 +1616,10 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "acceptType": {
-                            "type": "string",
-                            "enum": ["file", "url"]
-                          },
-                          "sortOrder": {
-                            "type": "integer"
-                          }
+                          "id": { "type": "string", "format": "uuid" },
+                          "name": { "type": "string" },
+                          "acceptType": { "type": "string", "enum": ["file", "url"] },
+                          "sortOrder": { "type": "integer" }
                         },
                         "required": ["id", "name", "acceptType", "sortOrder"]
                       }
@@ -2438,27 +1632,12 @@
                           "participation": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "editionId": {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              "universityId": {
-                                "type": "string"
-                              },
-                              "universityName": {
-                                "type": "string"
-                              },
-                              "teamName": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "createdAt": {
-                                "nullable": true
-                              }
+                              "id": { "type": "string", "format": "uuid" },
+                              "editionId": { "type": "string", "format": "uuid" },
+                              "universityId": { "type": "string" },
+                              "universityName": { "type": "string" },
+                              "teamName": { "type": "string", "nullable": true },
+                              "createdAt": { "nullable": true }
                             },
                             "required": [
                               "id",
@@ -2474,46 +1653,17 @@
                               "type": "object",
                               "nullable": true,
                               "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "format": "uuid"
-                                },
-                                "templateId": {
-                                  "type": "string",
-                                  "format": "uuid"
-                                },
-                                "participationId": {
-                                  "type": "string",
-                                  "format": "uuid"
-                                },
-                                "submittedBy": {
-                                  "type": "string"
-                                },
-                                "version": {
-                                  "type": "integer"
-                                },
-                                "fileName": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "fileSizeBytes": {
-                                  "type": "number",
-                                  "nullable": true
-                                },
-                                "fileMimeType": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "url": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "createdAt": {
-                                  "nullable": true
-                                },
-                                "updatedAt": {
-                                  "nullable": true
-                                }
+                                "id": { "type": "string", "format": "uuid" },
+                                "templateId": { "type": "string", "format": "uuid" },
+                                "participationId": { "type": "string", "format": "uuid" },
+                                "submittedBy": { "type": "string" },
+                                "version": { "type": "integer" },
+                                "fileName": { "type": "string", "nullable": true },
+                                "fileSizeBytes": { "type": "number", "nullable": true },
+                                "fileMimeType": { "type": "string", "nullable": true },
+                                "url": { "type": "string", "nullable": true },
+                                "createdAt": { "nullable": true },
+                                "updatedAt": { "nullable": true }
                               },
                               "required": [
                                 "id",
@@ -2535,24 +1685,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer"
-                        },
-                        "pageSize": {
-                          "type": "integer"
-                        },
-                        "total": {
-                          "type": "integer"
-                        },
-                        "totalPages": {
-                          "type": "integer"
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer" },
+                        "pageSize": { "type": "integer" },
+                        "total": { "type": "integer" },
+                        "totalPages": { "type": "integer" },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -2568,12 +1706,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -2585,12 +1718,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -2602,12 +1730,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -2619,14 +1742,7 @@
     "/api/submissions/{id}/download": {
       "get": {
         "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
+          { "schema": { "type": "string" }, "required": true, "name": "id", "in": "path" }
         ],
         "responses": {
           "200": {
@@ -2639,13 +1755,8 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "presignedUrl": {
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        "expiresIn": {
-                          "type": "integer"
-                        }
+                        "presignedUrl": { "type": "string", "format": "uri" },
+                        "expiresIn": { "type": "integer" }
                       },
                       "required": ["presignedUrl", "expiresIn"]
                     }
@@ -2662,10 +1773,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["File submission not found"]
-                    }
+                    "error": { "type": "string", "enum": ["File submission not found"] }
                   },
                   "required": ["error"]
                 }
@@ -2678,12 +1786,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -2695,12 +1798,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -2713,31 +1811,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -2754,10 +1840,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -2776,51 +1859,23 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "submissionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "version": {
-                            "type": "integer"
-                          },
-                          "submittedBy": {
-                            "type": "string"
-                          },
+                          "id": { "type": "string", "format": "uuid" },
+                          "submissionId": { "type": "string", "format": "uuid" },
+                          "version": { "type": "integer" },
+                          "submittedBy": { "type": "string" },
                           "submittedByUser": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
+                              "id": { "type": "string" },
+                              "name": { "type": "string" }
                             },
                             "required": ["id", "name"]
                           },
-                          "fileName": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "fileSizeBytes": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "fileMimeType": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "url": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          }
+                          "fileName": { "type": "string", "nullable": true },
+                          "fileSizeBytes": { "type": "number", "nullable": true },
+                          "fileMimeType": { "type": "string", "nullable": true },
+                          "url": { "type": "string", "nullable": true },
+                          "createdAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -2838,29 +1893,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -2876,12 +1914,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -2893,12 +1926,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -2910,12 +1938,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -2927,12 +1950,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -2944,14 +1962,7 @@
     "/api/submission-history/{historyId}/download": {
       "get": {
         "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "historyId",
-            "in": "path"
-          }
+          { "schema": { "type": "string" }, "required": true, "name": "historyId", "in": "path" }
         ],
         "responses": {
           "200": {
@@ -2964,13 +1975,8 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "presignedUrl": {
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        "expiresIn": {
-                          "type": "integer"
-                        }
+                        "presignedUrl": { "type": "string", "format": "uri" },
+                        "expiresIn": { "type": "integer" }
                       },
                       "required": ["presignedUrl", "expiresIn"]
                     }
@@ -2987,10 +1993,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["No file in this history entry"]
-                    }
+                    "error": { "type": "string", "enum": ["No file in this history entry"] }
                   },
                   "required": ["error"]
                 }
@@ -3003,12 +2006,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -3020,12 +2018,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -3038,31 +2031,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -3079,10 +2060,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -3101,44 +2079,19 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "participationId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "editionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "body": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          },
+                          "id": { "type": "string", "format": "uuid" },
+                          "participationId": { "type": "string", "format": "uuid" },
+                          "editionId": { "type": "string", "format": "uuid" },
+                          "body": { "type": "string" },
+                          "createdAt": { "nullable": true },
+                          "updatedAt": { "nullable": true },
                           "author": {
                             "type": "object",
                             "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "universityName": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "teamName": {
-                                "type": "string",
-                                "nullable": true
-                              }
+                              "id": { "type": "string" },
+                              "name": { "type": "string" },
+                              "universityName": { "type": "string", "nullable": true },
+                              "teamName": { "type": "string", "nullable": true }
                             },
                             "required": ["id", "name", "universityName", "teamName"]
                           }
@@ -3149,29 +2102,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -3187,12 +2123,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -3204,12 +2135,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -3221,12 +2147,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -3237,10 +2158,7 @@
       "post": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -3251,13 +2169,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "body": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 5000
-                  }
-                },
+                "properties": { "body": { "type": "string", "minLength": 1, "maxLength": 5000 } },
                 "required": ["body"]
               }
             }
@@ -3274,41 +2186,16 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "participationId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "authorId": {
-                          "type": "string"
-                        },
-                        "authorUniversityName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "authorTeamName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "body": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        },
-                        "deletedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "participationId": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "authorId": { "type": "string" },
+                        "authorUniversityName": { "type": "string", "nullable": true },
+                        "authorTeamName": { "type": "string", "nullable": true },
+                        "body": { "type": "string" },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true },
+                        "deletedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -3330,14 +2217,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -3347,12 +2227,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -3365,10 +2240,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Participation not found"]
-                    }
+                    "error": { "type": "string", "enum": ["Participation not found"] }
                   },
                   "required": ["error"]
                 }
@@ -3382,10 +2254,7 @@
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -3396,13 +2265,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "body": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 5000
-                  }
-                },
+                "properties": { "body": { "type": "string", "minLength": 1, "maxLength": 5000 } },
                 "required": ["body"]
               }
             }
@@ -3419,41 +2282,16 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "participationId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "authorId": {
-                          "type": "string"
-                        },
-                        "authorUniversityName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "authorTeamName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "body": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        },
-                        "deletedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "participationId": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "authorId": { "type": "string" },
+                        "authorUniversityName": { "type": "string", "nullable": true },
+                        "authorTeamName": { "type": "string", "nullable": true },
+                        "body": { "type": "string" },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true },
+                        "deletedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -3475,14 +2313,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -3492,12 +2323,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -3509,12 +2335,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -3525,31 +2346,21 @@
       "delete": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           }
         ],
         "responses": {
-          "204": {
-            "description": "コメント削除"
-          },
+          "204": { "description": "コメント削除" },
           "403": {
             "description": "権限なし",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -3566,27 +2377,11 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "participationId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "templateId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "fileName": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "contentType": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "fileSizeBytes": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "exclusiveMinimum": true
-                  }
+                  "participationId": { "type": "string", "format": "uuid" },
+                  "templateId": { "type": "string", "format": "uuid" },
+                  "fileName": { "type": "string", "minLength": 1 },
+                  "contentType": { "type": "string", "minLength": 1 },
+                  "fileSizeBytes": { "type": "integer", "minimum": 0, "exclusiveMinimum": true }
                 },
                 "required": [
                   "participationId",
@@ -3610,19 +2405,10 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "presignedUrl": {
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        "s3Key": {
-                          "type": "string"
-                        },
-                        "expiresIn": {
-                          "type": "integer"
-                        },
-                        "templateMaxFileSizeMb": {
-                          "type": "integer"
-                        }
+                        "presignedUrl": { "type": "string", "format": "uri" },
+                        "s3Key": { "type": "string" },
+                        "expiresIn": { "type": "integer" },
+                        "templateMaxFileSizeMb": { "type": "integer" }
                       },
                       "required": ["presignedUrl", "s3Key", "expiresIn", "templateMaxFileSizeMb"]
                     }
@@ -3636,14 +2422,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -3653,12 +2432,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Forbidden"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Forbidden"] } },
                   "required": ["error"]
                 }
               }
@@ -3670,11 +2444,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
+                  "properties": { "error": { "type": "string" } },
                   "required": ["error"]
                 }
               }
@@ -3704,22 +2474,13 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -3743,18 +2504,13 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "required": true,
             "name": "x-organization-id",
             "in": "header"
@@ -3773,23 +2529,11 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "userId": {
-                            "type": "string"
-                          },
-                          "role": {
-                            "type": "string",
-                            "enum": ["owner", "member"]
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "email": {
-                            "type": "string",
-                            "format": "email"
-                          }
+                          "id": { "type": "string" },
+                          "userId": { "type": "string" },
+                          "role": { "type": "string", "enum": ["owner", "member"] },
+                          "name": { "type": "string" },
+                          "email": { "type": "string", "format": "email" }
                         },
                         "required": ["id", "userId", "role", "name", "email"]
                       }
@@ -3797,29 +2541,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -3838,14 +2565,8 @@
                   "properties": {
                     "error": {
                       "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": ["x-organization-id is required"]
-                        },
-                        {
-                          "type": "string",
-                          "enum": ["Invalid query"]
-                        }
+                        { "type": "string", "enum": ["x-organization-id is required"] },
+                        { "type": "string", "enum": ["Invalid query"] }
                       ]
                     }
                   },
@@ -3860,12 +2581,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Owner only"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Owner only"] } },
                   "required": ["error"]
                 }
               }
@@ -3877,12 +2593,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -3895,9 +2606,7 @@
       "post": {
         "parameters": [
           {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "required": true,
             "name": "x-organization-id",
             "in": "header"
@@ -3909,14 +2618,8 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "email": {
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "role": {
-                    "type": "string",
-                    "enum": ["owner", "member"]
-                  }
+                  "email": { "type": "string", "format": "email" },
+                  "role": { "type": "string", "enum": ["owner", "member"] }
                 },
                 "required": ["email", "role"]
               }
@@ -3934,29 +2637,13 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "organizationId": {
-                          "type": "string"
-                        },
-                        "email": {
-                          "type": "string",
-                          "format": "email"
-                        },
-                        "role": {
-                          "type": "string",
-                          "enum": ["owner", "member"]
-                        },
-                        "inviterId": {
-                          "type": "string"
-                        },
-                        "expiresAt": {
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string" },
+                        "organizationId": { "type": "string" },
+                        "email": { "type": "string", "format": "email" },
+                        "role": { "type": "string", "enum": ["owner", "member"] },
+                        "inviterId": { "type": "string" },
+                        "expiresAt": { "nullable": true },
+                        "createdAt": { "nullable": true }
                       },
                       "required": ["id", "organizationId", "email", "role", "inviterId"]
                     }
@@ -3970,14 +2657,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -3987,12 +2667,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Owner only"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Owner only"] } },
                   "required": ["error"]
                 }
               }
@@ -4004,18 +2679,9 @@
     "/api/university/members/{id}/role": {
       "put": {
         "parameters": [
+          { "schema": { "type": "string" }, "required": true, "name": "id", "in": "path" },
           {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "required": true,
             "name": "x-organization-id",
             "in": "header"
@@ -4026,12 +2692,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "role": {
-                    "type": "string",
-                    "enum": ["owner", "member"]
-                  }
-                },
+                "properties": { "role": { "type": "string", "enum": ["owner", "member"] } },
                 "required": ["role"]
               }
             }
@@ -4048,16 +2709,9 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "userId": {
-                          "type": "string"
-                        },
-                        "role": {
-                          "type": "string",
-                          "enum": ["owner", "member"]
-                        }
+                        "id": { "type": "string" },
+                        "userId": { "type": "string" },
+                        "role": { "type": "string", "enum": ["owner", "member"] }
                       },
                       "required": ["id", "userId", "role"]
                     }
@@ -4076,16 +2730,9 @@
                   "properties": {
                     "error": {
                       "anyOf": [
-                        {
-                          "type": "string",
-                          "enum": ["x-organization-id is required"]
-                        },
-                        {
-                          "nullable": true
-                        },
-                        {
-                          "nullable": true
-                        }
+                        { "type": "string", "enum": ["x-organization-id is required"] },
+                        { "nullable": true },
+                        { "nullable": true }
                       ]
                     }
                   }
@@ -4099,12 +2746,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Owner only"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Owner only"] } },
                   "required": ["error"]
                 }
               }
@@ -4116,12 +2758,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -4134,10 +2771,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Last owner cannot be removed"]
-                    }
+                    "error": { "type": "string", "enum": ["Last owner cannot be removed"] }
                   },
                   "required": ["error"]
                 }
@@ -4150,27 +2784,16 @@
     "/api/university/members/{id}": {
       "delete": {
         "parameters": [
+          { "schema": { "type": "string" }, "required": true, "name": "id", "in": "path" },
           {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
+            "schema": { "type": "string" },
             "required": true,
             "name": "x-organization-id",
             "in": "header"
           }
         ],
         "responses": {
-          "204": {
-            "description": "メンバー削除"
-          },
+          "204": { "description": "メンバー削除" },
           "400": {
             "description": "組織指定不足",
             "content": {
@@ -4178,10 +2801,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["x-organization-id is required"]
-                    }
+                    "error": { "type": "string", "enum": ["x-organization-id is required"] }
                   },
                   "required": ["error"]
                 }
@@ -4194,12 +2814,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Owner only"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Owner only"] } },
                   "required": ["error"]
                 }
               }
@@ -4212,10 +2827,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Last owner cannot be removed"]
-                    }
+                    "error": { "type": "string", "enum": ["Last owner cannot be removed"] }
                   },
                   "required": ["error"]
                 }
@@ -4233,25 +2845,15 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  },
+                  "name": { "type": "string", "minLength": 1 },
+                  "description": { "type": "string" },
                   "externalLinks": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string",
-                          "format": "uri"
-                        }
+                        "label": { "type": "string" },
+                        "url": { "type": "string", "format": "uri" }
                       },
                       "required": ["label", "url"]
                     }
@@ -4273,40 +2875,23 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "externalLinks": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": ["id", "name", "description", "externalLinks"]
                     }
@@ -4320,14 +2905,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           }
@@ -4338,10 +2916,7 @@
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -4353,25 +2928,15 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  },
+                  "name": { "type": "string", "minLength": 1 },
+                  "description": { "type": "string" },
                   "externalLinks": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string",
-                          "format": "uri"
-                        }
+                        "label": { "type": "string" },
+                        "url": { "type": "string", "format": "uri" }
                       },
                       "required": ["label", "url"]
                     }
@@ -4393,40 +2958,23 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "externalLinks": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": ["id", "name", "description", "externalLinks"]
                     }
@@ -4440,14 +2988,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -4457,12 +2998,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -4473,20 +3009,13 @@
       "delete": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "シリーズ削除"
-          }
-        }
+        "responses": { "204": { "description": "シリーズ削除" } }
       }
     },
     "/api/admin/editions": {
@@ -4497,20 +3026,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "seriesId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "year": {
-                    "type": "integer"
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  },
+                  "seriesId": { "type": "string", "format": "uuid" },
+                  "year": { "type": "integer" },
+                  "name": { "type": "string", "minLength": 1 },
+                  "description": { "type": "string" },
                   "sharingStatus": {
                     "type": "string",
                     "enum": ["draft", "accepting", "sharing", "closed"],
@@ -4521,13 +3040,8 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string",
-                          "format": "uri"
-                        }
+                        "label": { "type": "string" },
+                        "url": { "type": "string", "format": "uri" }
                       },
                       "required": ["label", "url"]
                     }
@@ -4549,43 +3063,21 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "seriesId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "year": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "seriesId": { "type": "string", "format": "uuid" },
+                        "year": { "type": "integer" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "ruleDocuments": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "s3_key": {
-                                "type": "string"
-                              },
-                              "mime_type": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "s3_key": { "type": "string" },
+                              "mime_type": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "s3_key", "mime_type", "url"]
                           }
@@ -4600,23 +3092,14 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -4639,14 +3122,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           }
@@ -4657,10 +3133,7 @@
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -4672,20 +3145,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "seriesId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "year": {
-                    "type": "integer"
-                  },
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  },
+                  "seriesId": { "type": "string", "format": "uuid" },
+                  "year": { "type": "integer" },
+                  "name": { "type": "string", "minLength": 1 },
+                  "description": { "type": "string" },
                   "sharingStatus": {
                     "type": "string",
                     "enum": ["draft", "accepting", "sharing", "closed"],
@@ -4696,13 +3159,8 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string",
-                          "format": "uri"
-                        }
+                        "label": { "type": "string" },
+                        "url": { "type": "string", "format": "uri" }
                       },
                       "required": ["label", "url"]
                     }
@@ -4724,43 +3182,21 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "seriesId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "year": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "seriesId": { "type": "string", "format": "uuid" },
+                        "year": { "type": "integer" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "ruleDocuments": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "s3_key": {
-                                "type": "string"
-                              },
-                              "mime_type": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "s3_key": { "type": "string" },
+                              "mime_type": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "s3_key", "mime_type", "url"]
                           }
@@ -4775,23 +3211,14 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -4814,14 +3241,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -4831,12 +3251,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -4847,30 +3262,20 @@
       "delete": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "大会開催回削除"
-          }
-        }
+        "responses": { "204": { "description": "大会開催回削除" } }
       }
     },
     "/api/admin/editions/{id}/status": {
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -4903,43 +3308,21 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "seriesId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "year": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "seriesId": { "type": "string", "format": "uuid" },
+                        "year": { "type": "integer" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "ruleDocuments": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "s3_key": {
-                                "type": "string"
-                              },
-                              "mime_type": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "s3_key": { "type": "string" },
+                              "mime_type": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "s3_key", "mime_type", "url"]
                           }
@@ -4954,23 +3337,14 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -4993,14 +3367,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -5010,12 +3377,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -5028,10 +3390,7 @@
       "post": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -5043,14 +3402,8 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "fileName": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "contentType": {
-                    "type": "string",
-                    "minLength": 1
-                  }
+                  "fileName": { "type": "string", "minLength": 1 },
+                  "contentType": { "type": "string", "minLength": 1 }
                 },
                 "required": ["fileName", "contentType"]
               }
@@ -5068,16 +3421,9 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "presignedUrl": {
-                          "type": "string",
-                          "format": "uri"
-                        },
-                        "s3Key": {
-                          "type": "string"
-                        },
-                        "expiresIn": {
-                          "type": "integer"
-                        }
+                        "presignedUrl": { "type": "string", "format": "uri" },
+                        "s3Key": { "type": "string" },
+                        "expiresIn": { "type": "integer" }
                       },
                       "required": ["presignedUrl", "s3Key", "expiresIn"]
                     }
@@ -5091,14 +3437,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           }
@@ -5109,10 +3448,7 @@
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -5129,17 +3465,9 @@
                     "items": {
                       "type": "object",
                       "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "s3_key": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "mime_type": {
-                          "type": "string",
-                          "minLength": 1
-                        }
+                        "label": { "type": "string" },
+                        "s3_key": { "type": "string", "minLength": 1 },
+                        "mime_type": { "type": "string", "minLength": 1 }
                       },
                       "required": ["label", "s3_key", "mime_type"]
                     }
@@ -5161,43 +3489,21 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "seriesId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "year": {
-                          "type": "integer"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "seriesId": { "type": "string", "format": "uuid" },
+                        "year": { "type": "integer" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
                         "ruleDocuments": {
                           "type": "array",
                           "nullable": true,
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "s3_key": {
-                                "type": "string"
-                              },
-                              "mime_type": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "s3_key": { "type": "string" },
+                              "mime_type": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "s3_key", "mime_type", "url"]
                           }
@@ -5212,23 +3518,14 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "label": {
-                                "type": "string"
-                              },
-                              "url": {
-                                "type": "string",
-                                "format": "uri"
-                              }
+                              "label": { "type": "string" },
+                              "url": { "type": "string", "format": "uri" }
                             },
                             "required": ["label", "url"]
                           }
                         },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -5251,14 +3548,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -5268,12 +3558,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -5286,31 +3571,19 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -5347,27 +3620,12 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "editionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "universityId": {
-                            "type": "string"
-                          },
-                          "universityName": {
-                            "type": "string"
-                          },
-                          "teamName": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          }
+                          "id": { "type": "string", "format": "uuid" },
+                          "editionId": { "type": "string", "format": "uuid" },
+                          "universityId": { "type": "string" },
+                          "universityName": { "type": "string" },
+                          "teamName": { "type": "string", "nullable": true },
+                          "createdAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -5381,29 +3639,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -5419,12 +3660,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -5436,12 +3672,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
                   "required": ["error"]
                 }
               }
@@ -5452,10 +3683,7 @@
       "post": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -5467,13 +3695,8 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "universityId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "teamName": {
-                    "type": "string"
-                  }
+                  "universityId": { "type": "string", "minLength": 1 },
+                  "teamName": { "type": "string" }
                 },
                 "required": ["universityId"]
               }
@@ -5491,27 +3714,12 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "universityId": {
-                          "type": "string"
-                        },
-                        "teamName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "universityId": { "type": "string" },
+                        "teamName": { "type": "string", "nullable": true },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": ["id", "editionId", "universityId", "teamName"]
                     }
@@ -5525,14 +3733,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           }
@@ -5543,10 +3744,7 @@
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -5557,12 +3755,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "teamName": {
-                    "type": "string",
-                    "nullable": true
-                  }
-                }
+                "properties": { "teamName": { "type": "string", "nullable": true } }
               }
             }
           }
@@ -5578,27 +3771,12 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "universityId": {
-                          "type": "string"
-                        },
-                        "teamName": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "universityId": { "type": "string" },
+                        "teamName": { "type": "string", "nullable": true },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": ["id", "editionId", "universityId", "teamName"]
                     }
@@ -5612,14 +3790,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -5629,12 +3800,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -5645,30 +3811,20 @@
       "delete": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "参加チーム削除"
-          }
-        }
+        "responses": { "204": { "description": "参加チーム削除" } }
       }
     },
     "/api/admin/editions/{id}/templates": {
       "post": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -5680,40 +3836,19 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "acceptType": {
-                    "type": "string",
-                    "enum": ["file", "url"]
-                  },
-                  "allowedExtensions": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "urlPattern": {
-                    "type": "string"
-                  },
+                  "name": { "type": "string", "minLength": 1 },
+                  "description": { "type": "string" },
+                  "acceptType": { "type": "string", "enum": ["file", "url"] },
+                  "allowedExtensions": { "type": "array", "items": { "type": "string" } },
+                  "urlPattern": { "type": "string" },
                   "maxFileSizeMb": {
                     "type": "integer",
                     "minimum": 0,
                     "exclusiveMinimum": true,
                     "default": 100
                   },
-                  "isRequired": {
-                    "type": "boolean",
-                    "default": false
-                  },
-                  "sortOrder": {
-                    "type": "integer",
-                    "default": 0
-                  }
+                  "isRequired": { "type": "boolean", "default": false },
+                  "sortOrder": { "type": "integer", "default": 0 }
                 },
                 "required": ["name", "acceptType"]
               }
@@ -5731,51 +3866,22 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "acceptType": {
-                          "type": "string",
-                          "enum": ["file", "url"]
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
+                        "acceptType": { "type": "string", "enum": ["file", "url"] },
                         "allowedExtensions": {
                           "type": "array",
                           "nullable": true,
-                          "items": {
-                            "type": "string"
-                          }
+                          "items": { "type": "string" }
                         },
-                        "urlPattern": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "maxFileSizeMb": {
-                          "type": "integer"
-                        },
-                        "isRequired": {
-                          "type": "boolean"
-                        },
-                        "sortOrder": {
-                          "type": "integer"
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "urlPattern": { "type": "string", "nullable": true },
+                        "maxFileSizeMb": { "type": "integer" },
+                        "isRequired": { "type": "boolean" },
+                        "sortOrder": { "type": "integer" },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -5800,14 +3906,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           }
@@ -5818,10 +3917,7 @@
       "put": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
@@ -5833,40 +3929,19 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "acceptType": {
-                    "type": "string",
-                    "enum": ["file", "url"]
-                  },
-                  "allowedExtensions": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "urlPattern": {
-                    "type": "string"
-                  },
+                  "name": { "type": "string", "minLength": 1 },
+                  "description": { "type": "string" },
+                  "acceptType": { "type": "string", "enum": ["file", "url"] },
+                  "allowedExtensions": { "type": "array", "items": { "type": "string" } },
+                  "urlPattern": { "type": "string" },
                   "maxFileSizeMb": {
                     "type": "integer",
                     "minimum": 0,
                     "exclusiveMinimum": true,
                     "default": 100
                   },
-                  "isRequired": {
-                    "type": "boolean",
-                    "default": false
-                  },
-                  "sortOrder": {
-                    "type": "integer",
-                    "default": 0
-                  }
+                  "isRequired": { "type": "boolean", "default": false },
+                  "sortOrder": { "type": "integer", "default": 0 }
                 },
                 "required": ["name", "acceptType"]
               }
@@ -5884,51 +3959,22 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "editionId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "acceptType": {
-                          "type": "string",
-                          "enum": ["file", "url"]
-                        },
+                        "id": { "type": "string", "format": "uuid" },
+                        "editionId": { "type": "string", "format": "uuid" },
+                        "name": { "type": "string" },
+                        "description": { "type": "string", "nullable": true },
+                        "acceptType": { "type": "string", "enum": ["file", "url"] },
                         "allowedExtensions": {
                           "type": "array",
                           "nullable": true,
-                          "items": {
-                            "type": "string"
-                          }
+                          "items": { "type": "string" }
                         },
-                        "urlPattern": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "maxFileSizeMb": {
-                          "type": "integer"
-                        },
-                        "isRequired": {
-                          "type": "boolean"
-                        },
-                        "sortOrder": {
-                          "type": "integer"
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "urlPattern": { "type": "string", "nullable": true },
+                        "maxFileSizeMb": { "type": "integer" },
+                        "isRequired": { "type": "boolean" },
+                        "sortOrder": { "type": "integer" },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": [
                         "id",
@@ -5953,14 +3999,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           },
@@ -5970,12 +4009,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Not found"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
                   "required": ["error"]
                 }
               }
@@ -5986,39 +4020,26 @@
       "delete": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           }
         ],
-        "responses": {
-          "204": {
-            "description": "テンプレート削除"
-          }
-        }
+        "responses": { "204": { "description": "テンプレート削除" } }
       }
     },
     "/api/admin/editions/{id}/templates/copy-from/{sourceEditionId}": {
       "post": {
         "parameters": [
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "id",
             "in": "path"
           },
           {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
+            "schema": { "type": "string", "format": "uuid" },
             "required": true,
             "name": "sourceEditionId",
             "in": "path"
@@ -6037,51 +4058,22 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "editionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "acceptType": {
-                            "type": "string",
-                            "enum": ["file", "url"]
-                          },
+                          "id": { "type": "string", "format": "uuid" },
+                          "editionId": { "type": "string", "format": "uuid" },
+                          "name": { "type": "string" },
+                          "description": { "type": "string", "nullable": true },
+                          "acceptType": { "type": "string", "enum": ["file", "url"] },
                           "allowedExtensions": {
                             "type": "array",
                             "nullable": true,
-                            "items": {
-                              "type": "string"
-                            }
+                            "items": { "type": "string" }
                           },
-                          "urlPattern": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "maxFileSizeMb": {
-                            "type": "integer"
-                          },
-                          "isRequired": {
-                            "type": "boolean"
-                          },
-                          "sortOrder": {
-                            "type": "integer"
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          }
+                          "urlPattern": { "type": "string", "nullable": true },
+                          "maxFileSizeMb": { "type": "integer" },
+                          "isRequired": { "type": "boolean" },
+                          "sortOrder": { "type": "integer" },
+                          "createdAt": { "nullable": true },
+                          "updatedAt": { "nullable": true }
                         },
                         "required": [
                           "id",
@@ -6114,18 +4106,9 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "slug": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "ownerEmail": {
-                    "type": "string",
-                    "format": "email"
-                  }
+                  "name": { "type": "string", "minLength": 1 },
+                  "slug": { "type": "string", "minLength": 1 },
+                  "ownerEmail": { "type": "string", "format": "email" }
                 },
                 "required": ["name", "slug"]
               }
@@ -6143,21 +4126,11 @@
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "slug": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "nullable": true
-                        },
-                        "updatedAt": {
-                          "nullable": true
-                        }
+                        "id": { "type": "string" },
+                        "name": { "type": "string" },
+                        "slug": { "type": "string" },
+                        "createdAt": { "nullable": true },
+                        "updatedAt": { "nullable": true }
                       },
                       "required": ["id", "name", "slug"]
                     }
@@ -6171,14 +4144,7 @@
             "description": "不正入力",
             "content": {
               "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "nullable": true
-                    }
-                  }
-                }
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
               }
             }
           }
@@ -6187,22 +4153,13 @@
       "get": {
         "parameters": [
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
             "required": false,
             "name": "page",
             "in": "query"
           },
           {
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 20
-            },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
             "required": false,
             "name": "pageSize",
             "in": "query"
@@ -6226,10 +4183,7 @@
             "in": "query"
           },
           {
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            },
+            "schema": { "type": "string", "minLength": 1 },
             "required": false,
             "name": "q",
             "in": "query"
@@ -6248,21 +4202,11 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "slug": {
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "nullable": true
-                          },
-                          "updatedAt": {
-                            "nullable": true
-                          }
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "slug": { "type": "string" },
+                          "createdAt": { "nullable": true },
+                          "updatedAt": { "nullable": true }
                         },
                         "required": ["id", "name", "slug"]
                       }
@@ -6270,29 +4214,12 @@
                     "pagination": {
                       "type": "object",
                       "properties": {
-                        "page": {
-                          "type": "integer",
-                          "minimum": 1
-                        },
-                        "pageSize": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 100
-                        },
-                        "total": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "totalPages": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "hasNext": {
-                          "type": "boolean"
-                        },
-                        "hasPrev": {
-                          "type": "boolean"
-                        }
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
                       },
                       "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
@@ -6308,12 +4235,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid query"]
-                    }
-                  },
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
                   "required": ["error"]
                 }
               }
@@ -6325,11 +4247,362 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users": {
+      "get": {
+        "parameters": [
+          {
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 },
+            "required": false,
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "example": "name:asc",
+              "enum": [
+                "name:asc",
+                "name:desc",
+                "email:asc",
+                "email:desc",
+                "createdAt:asc",
+                "createdAt:desc"
+              ]
+            },
+            "required": false,
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "schema": { "type": "string", "minLength": 1 },
+            "required": false,
+            "name": "q",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ユーザー一覧",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
                   "properties": {
-                    "error": {
-                      "type": "string",
-                      "enum": ["Invalid sort"]
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "email": { "type": "string", "format": "email" },
+                          "isAdmin": { "type": "boolean" },
+                          "createdAt": { "nullable": true },
+                          "organizationCount": { "type": "number" }
+                        },
+                        "required": ["id", "name", "email", "isAdmin", "organizationCount"]
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "page": { "type": "integer", "minimum": 1 },
+                        "pageSize": { "type": "integer", "minimum": 1, "maximum": 100 },
+                        "total": { "type": "integer", "minimum": 0 },
+                        "totalPages": { "type": "integer", "minimum": 0 },
+                        "hasNext": { "type": "boolean" },
+                        "hasPrev": { "type": "boolean" }
+                      },
+                      "required": ["page", "pageSize", "total", "totalPages", "hasNext", "hasPrev"]
                     }
+                  },
+                  "required": ["data", "pagination"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正クエリ",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Invalid query"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "不正ソート",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Invalid sort"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{userId}/memberships": {
+      "get": {
+        "parameters": [
+          { "schema": { "type": "string" }, "required": true, "name": "userId", "in": "path" }
+        ],
+        "responses": {
+          "200": {
+            "description": "ユーザー所属一覧",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "memberId": { "type": "string" },
+                          "organizationId": { "type": "string" },
+                          "organizationName": { "type": "string" },
+                          "organizationSlug": { "type": "string" },
+                          "role": { "type": "string", "enum": ["owner", "member"] },
+                          "createdAt": { "nullable": true }
+                        },
+                        "required": [
+                          "memberId",
+                          "organizationId",
+                          "organizationName",
+                          "organizationSlug",
+                          "role"
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ユーザー未検出",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          { "schema": { "type": "string" }, "required": true, "name": "userId", "in": "path" }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "organizationId": { "type": "string", "minLength": 1 },
+                  "role": { "type": "string", "enum": ["owner", "member"] }
+                },
+                "required": ["organizationId", "role"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "所属作成",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "userId": { "type": "string" },
+                        "organizationId": { "type": "string" },
+                        "role": { "type": "string", "enum": ["owner", "member"] },
+                        "createdAt": { "nullable": true }
+                      },
+                      "required": ["id", "userId", "organizationId", "role"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正入力",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
+              }
+            }
+          },
+          "404": {
+            "description": "対象未検出",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "重複所属",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string", "enum": ["Membership already exists"] }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/memberships/{memberId}/role": {
+      "put": {
+        "parameters": [
+          { "schema": { "type": "string" }, "required": true, "name": "memberId", "in": "path" }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": { "role": { "type": "string", "enum": ["owner", "member"] } },
+                "required": ["role"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "所属ロール更新",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "userId": { "type": "string" },
+                        "organizationId": { "type": "string" },
+                        "role": { "type": "string", "enum": ["owner", "member"] },
+                        "createdAt": { "nullable": true }
+                      },
+                      "required": ["id", "userId", "organizationId", "role"]
+                    }
+                  },
+                  "required": ["data"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "不正入力",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object", "properties": { "error": { "nullable": true } } }
+              }
+            }
+          },
+          "404": {
+            "description": "所属未検出",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "最後のowner保護",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string", "enum": ["Last owner cannot be removed"] }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/memberships/{memberId}": {
+      "delete": {
+        "parameters": [
+          { "schema": { "type": "string" }, "required": true, "name": "memberId", "in": "path" }
+        ],
+        "responses": {
+          "204": { "description": "所属解除" },
+          "404": {
+            "description": "所属未検出",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "error": { "type": "string", "enum": ["Not found"] } },
+                  "required": ["error"]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "最後のowner保護",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string", "enum": ["Last owner cannot be removed"] }
                   },
                   "required": ["error"]
                 }


### PR DESCRIPTION
## 概要
Issue #18 の管理者向けユーザー運用機能を実装しました。管理画面から横断的にユーザーを検索し、大学所属の追加・ロール変更・所属解除を行えるようにしています。

### backend の変更
- `adminUserRoutes` を追加し、`/api/admin/*` 配下にユーザー一覧・所属管理 API を実装
- `app.ts` に admin users ルートを登録
- `membership-management.ts` に `getMemberById` を追加し、最後の owner 保護ロジックを共通化
- 重複所属の競合（DB unique 制約 `member_org_user_unique`）を 409 にマッピング
- 統合テストを追加・拡張（admin users CRUD、非 admin アクセス拒否、race duplicate の 409 など）

### frontend の変更
- 管理画面に `/admin/users` を追加（検索・ソート・ページング対応のユーザー一覧）
- ユーザーごとの所属管理ダイアログを追加
  - 大学所属追加（`UniversitySelect` 再利用 + role 指定）
  - 所属ロール変更
  - 所属解除
- 管理ダッシュボードと管理サイドナビに「ユーザー管理」導線を追加
- TanStack Query key に `queryKeys.admin.users(...)` / `queryKeys.admin.userMemberships(userId)` を追加
- OpenAPI 更新に伴い frontend API schema を更新

## 追加 API 一覧
- `GET /api/admin/users`
- `GET /api/admin/users/{userId}/memberships`
- `POST /api/admin/users/{userId}/memberships`
- `PUT /api/admin/memberships/{memberId}/role`
- `DELETE /api/admin/memberships/{memberId}`

## テスト結果
`pnpm run ci` を実行し、以下すべて成功。
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`

実行結果（抜粋）:
- Test Files: 13 passed
- Tests: 56 passed

## 既知の残課題
- フロントの「主要導線テスト（UIテスト）」は本PRでは未追加です（Issue受け入れ基準の品質項目のうち残件）。
- `vitest.workspace.ts` 利用に対する非推奨警告が出るため、将来的に root 設定の `test.projects` への移行が必要です。

Closes #18
