### PR TITLE
refactor(frontend): TanStack Query/Form分離を残ページ全体へ横展開

### DIFF
--- a/apps/frontend/app/(admin)/admin/editions/[id]/participations/page.tsx
+++ b/apps/frontend/app/(admin)/admin/editions/[id]/participations/page.tsx
@@ -5,23 +5,13 @@ import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { DataTable } from '@/components/common/DataTable';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type Participation,
+  useAdminParticipationsPage,
+} from '@/features/admin/participations/hooks';
 import type { ColumnDef } from '@tanstack/react-table';
 import { CheckIcon, PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
-import { use, useState } from 'react';
-import { toast } from 'sonner';
-
-type Participation = {
-  id: string;
-  editionId: string;
-  universityId: string;
-  universityName: string;
-  teamName: string | null;
-  createdAt: unknown;
-};
+import { use } from 'react';
 
 export default function AdminParticipationsPage({
   params,
@@ -29,68 +19,21 @@ export default function AdminParticipationsPage({
   params: Promise<{ id: string }>;
 }) {
   const { id: editionId } = use(params);
-  const queryClient = useQueryClient();
-  const [selectedUniversityId, setSelectedUniversityId] = useState('');
-  const [teamName, setTeamName] = useState('');
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingTeamName, setEditingTeamName] = useState('');
-
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.participations(editionId, {}),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/admin/editions/{id}/participations', {
-        params: { path: { id: editionId } },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const createMutation = useMutation({
-    mutationFn: async () => {
-      const result = await apiClient.POST('/api/admin/editions/{id}/participations', {
-        params: { path: { id: editionId } },
-        body: { universityId: selectedUniversityId, teamName: teamName || undefined },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.participations(editionId, {}) });
-      setSelectedUniversityId('');
-      setTeamName('');
-      toast.success('出場登録しました');
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: async ({ id, teamName }: { id: string; teamName: string | null }) => {
-      const result = await apiClient.PUT('/api/admin/participations/{id}', {
-        params: { path: { id } },
-        body: { teamName: teamName || null },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.participations(editionId, {}) });
-      setEditingId(null);
-      toast.success('更新しました');
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const result = await apiClient.DELETE('/api/admin/participations/{id}', {
-        params: { path: { id } },
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.participations(editionId, {}) });
-      toast.success('削除しました');
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
+  const {
+    selectedUniversityId,
+    setSelectedUniversityId,
+    teamName,
+    setTeamName,
+    editingId,
+    setEditingId,
+    editingTeamName,
+    setEditingTeamName,
+    data,
+    isLoading,
+    createMutation,
+    updateMutation,
+    deleteMutation,
+  } = useAdminParticipationsPage(editionId);
   const columns: ColumnDef<Participation>[] = [
     { header: '大学名', accessorKey: 'universityName' },
     {

--- a/apps/frontend/app/(admin)/admin/editions/[id]/templates/page.tsx
+++ b/apps/frontend/app/(admin)/admin/editions/[id]/templates/page.tsx
@@ -18,352 +18,35 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { TemplateFormDialog } from '@/features/admin/templates/TemplateFormDialog';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { useForm } from '@tanstack/react-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+  useCopyTemplatesMutation,
+  useDeleteTemplateMutation,
+} from '@/features/admin/templates/mutations';
+import { useAdminTemplates, useEditionsForTemplateCopy } from '@/features/admin/templates/query';
+import type { Template } from '@/features/admin/templates/types';
 import type { ColumnDef } from '@tanstack/react-table';
 import { CheckIcon, CopyIcon, PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { use, useState } from 'react';
-import { toast } from 'sonner';
-import { z } from 'zod';
-
-const ACCEPT_TYPE_LABELS: Record<Template['acceptType'], string> = {
-  file: 'ファイル',
-  url: 'URL',
-};
-
-type Template = {
-  id: string;
-  name: string;
-  description: string | null;
-  acceptType: 'file' | 'url';
-  allowedExtensions: string[] | null;
-  urlPattern: string | null;
-  maxFileSizeMb: number;
-  isRequired: boolean;
-  sortOrder: number;
-  createdAt: unknown;
-};
-
-function TemplateFormDialog({
-  editionId,
-  editing,
-  onClose,
-}: {
-  editionId: string;
-  editing: Template | null;
-  onClose: () => void;
-}) {
-  const queryClient = useQueryClient();
-  const form = useForm({
-    defaultValues: {
-      name: editing?.name ?? '',
-      description: editing?.description ?? '',
-      acceptType: (editing?.acceptType ?? 'file') as 'file' | 'url',
-      allowedExtensions: editing?.allowedExtensions?.join(', ') ?? '',
-      urlPattern: editing?.urlPattern ?? '',
-      maxFileSizeMb: editing?.maxFileSizeMb ?? 100,
-      isRequired: editing?.isRequired ?? false,
-      sortOrder: editing?.sortOrder ?? 0,
-    },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  const mutation = useMutation({
-    mutationFn: async (values: {
-      name: string;
-      description: string;
-      acceptType: 'file' | 'url';
-      allowedExtensions: string;
-      urlPattern: string;
-      maxFileSizeMb: number;
-      isRequired: boolean;
-      sortOrder: number;
-    }) => {
-      const body = {
-        name: values.name,
-        description: values.description,
-        acceptType: values.acceptType,
-        allowedExtensions:
-          values.acceptType === 'file' && values.allowedExtensions
-            ? values.allowedExtensions
-                .split(',')
-                .map((e) => e.trim())
-                .filter(Boolean)
-            : undefined,
-        urlPattern: values.acceptType === 'url' ? values.urlPattern : undefined,
-        maxFileSizeMb: values.maxFileSizeMb,
-        isRequired: values.isRequired,
-        sortOrder: values.sortOrder,
-      };
-      if (editing) {
-        const r = await apiClient.PUT('/api/admin/templates/{id}', {
-          params: { path: { id: editing.id } },
-          body,
-        });
-        return throwIfError(r);
-      }
-      const r = await apiClient.POST('/api/admin/editions/{id}/templates', {
-        params: { path: { id: editionId } },
-        body,
-      });
-      return throwIfError(r);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.templates(editionId, {}) });
-      toast.success(editing ? '更新しました' : '作成しました');
-      onClose();
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  return (
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>{editing ? 'テンプレートを編集' : '新規テンプレート作成'}</DialogTitle>
-      </DialogHeader>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          form.handleSubmit();
-        }}
-        className='space-y-4'
-      >
-        <form.Field
-          name='name'
-          validators={{ onChange: z.string().min(1, '名称を入力してください') }}
-        >
-          {(field) => (
-            <div className='space-y-1'>
-              <label htmlFor={field.name} className='text-sm font-medium'>
-                名称 *
-              </label>
-              <Input
-                id={field.name}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-              {field.state.meta.errors[0] && (
-                <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
-              )}
-            </div>
-          )}
-        </form.Field>
-        <form.Field name='description'>
-          {(field) => (
-            <div className='space-y-1'>
-              <label htmlFor={field.name} className='text-sm font-medium'>
-                説明
-              </label>
-              <Textarea
-                id={field.name}
-                rows={2}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-            </div>
-          )}
-        </form.Field>
-        <form.Field name='acceptType'>
-          {(field) => (
-            <div className='space-y-1'>
-              <span className='text-sm font-medium'>種別</span>
-              <Select
-                value={field.state.value}
-                onValueChange={(v) => field.handleChange((v ?? 'file') as 'file' | 'url')}
-              >
-                <SelectTrigger>
-                  <SelectValue>{ACCEPT_TYPE_LABELS[field.state.value]}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value='file'>ファイル</SelectItem>
-                  <SelectItem value='url'>URL</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-        </form.Field>
-        <form.Subscribe selector={(state) => state.values.acceptType}>
-          {(acceptType) => (
-            <>
-              {acceptType === 'file' && (
-                <>
-                  <form.Field name='allowedExtensions'>
-                    {(field) => (
-                      <div className='space-y-1'>
-                        <label htmlFor={field.name} className='text-sm font-medium'>
-                          許可拡張子（カンマ区切り）
-                        </label>
-                        <Input
-                          id={field.name}
-                          placeholder='pdf, docx'
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
-                          onChange={(e) => field.handleChange(e.target.value)}
-                        />
-                      </div>
-                    )}
-                  </form.Field>
-                  <form.Field name='maxFileSizeMb'>
-                    {(field) => (
-                      <div className='space-y-1'>
-                        <label htmlFor={field.name} className='text-sm font-medium'>
-                          最大ファイルサイズ (MB)
-                        </label>
-                        <Input
-                          id={field.name}
-                          type='number'
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
-                          onChange={(e) => field.handleChange(Number(e.target.value))}
-                        />
-                      </div>
-                    )}
-                  </form.Field>
-                </>
-              )}
-              {acceptType === 'url' && (
-                <form.Field name='urlPattern'>
-                  {(field) => (
-                    <div className='space-y-1'>
-                      <label htmlFor={field.name} className='text-sm font-medium'>
-                        URLパターン（ヒント用）
-                      </label>
-                      <Input
-                        id={field.name}
-                        placeholder='github.com'
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                      />
-                    </div>
-                  )}
-                </form.Field>
-              )}
-            </>
-          )}
-        </form.Subscribe>
-        <div className='flex gap-4'>
-          <form.Field name='isRequired'>
-            {(field) => (
-              <div className='flex items-center gap-2'>
-                <Switch
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                />
-                <span className='text-sm font-medium'>必須</span>
-              </div>
-            )}
-          </form.Field>
-          <form.Field name='sortOrder'>
-            {(field) => (
-              <div className='flex items-center gap-2'>
-                <label htmlFor={field.name} className='text-sm font-medium'>
-                  順序
-                </label>
-                <Input
-                  id={field.name}
-                  type='number'
-                  className='w-16 h-8'
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(Number(e.target.value))}
-                />
-              </div>
-            )}
-          </form.Field>
-        </div>
-        <div className='flex justify-end gap-2'>
-          <Button type='button' variant='ghost' onClick={onClose}>
-            キャンセル
-          </Button>
-          <Button type='submit' disabled={mutation.isPending}>
-            {editing ? '更新' : '作成'}
-          </Button>
-        </div>
-      </form>
-    </DialogContent>
-  );
-}
 
 export default function AdminTemplatesPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: editionId } = use(params);
-  const queryClient = useQueryClient();
   const [editingItem, setEditingItem] = useState<Template | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [copyDialogOpen, setCopyDialogOpen] = useState(false);
   const [sourceEditionId, setSourceEditionId] = useState('');
   const [comboOpen, setComboOpen] = useState(false);
 
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.templates(editionId, {}),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/editions/{id}/templates', {
-        params: { path: { id: editionId }, query: { pageSize: 100 } },
-      });
-      return throwIfError(result);
-    },
+  const { data, isLoading } = useAdminTemplates(editionId);
+  const { data: editionsData } = useEditionsForTemplateCopy();
+  const deleteMutation = useDeleteTemplateMutation(editionId);
+  const copyMutation = useCopyTemplatesMutation(editionId, () => {
+    setCopyDialogOpen(false);
   });
 
-  const { data: editionsData } = useQuery({
-    queryKey: ['editions-all-for-copy'],
-    queryFn: async () => {
-      const r = await apiClient.GET('/api/editions', { params: { query: { pageSize: 100 } } });
-      return throwIfError(r);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const result = await apiClient.DELETE('/api/admin/templates/{id}', {
-        params: { path: { id } },
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.templates(editionId, {}) });
-      toast.success('削除しました');
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const copyMutation = useMutation({
-    mutationFn: async (sourceId: string) => {
-      const result = await apiClient.POST(
-        '/api/admin/editions/{id}/templates/copy-from/{sourceEditionId}',
-        {
-          params: { path: { id: editionId, sourceEditionId: sourceId } },
-        },
-      );
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.templates(editionId, {}) });
-      toast.success('テンプレートをコピーしました');
-      setCopyDialogOpen(false);
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const otherEditions = (editionsData?.data ?? []).filter((e) => e.id !== editionId);
-  const selectedEdition = otherEditions.find((e) => e.id === sourceEditionId);
+  const otherEditions = (editionsData?.data ?? []).filter((edition) => edition.id !== editionId);
+  const selectedEdition = otherEditions.find((edition) => edition.id === sourceEditionId);
 
   const columns: ColumnDef<Template>[] = [
     { header: '順序', cell: ({ row }) => row.original.sortOrder },
@@ -447,17 +130,19 @@ export default function AdminTemplatesPage({ params }: { params: Promise<{ id: s
                       <CommandInput placeholder='検索...' />
                       <CommandEmpty>見つかりません</CommandEmpty>
                       <CommandGroup>
-                        {otherEditions.map((e) => (
+                        {otherEditions.map((edition) => (
                           <CommandItem
-                            key={e.id}
-                            value={`${e.year} ${e.name}`}
+                            key={edition.id}
+                            value={`${edition.year} ${edition.name}`}
                             onSelect={() => {
-                              setSourceEditionId(e.id);
+                              setSourceEditionId(edition.id);
                               setComboOpen(false);
                             }}
                           >
-                            {sourceEditionId === e.id && <CheckIcon className='h-3 w-3 mr-1' />}
-                            {e.year}年 {e.name}
+                            {sourceEditionId === edition.id && (
+                              <CheckIcon className='h-3 w-3 mr-1' />
+                            )}
+                            {edition.year}年 {edition.name}
                           </CommandItem>
                         ))}
                       </CommandGroup>
@@ -483,7 +168,9 @@ export default function AdminTemplatesPage({ params }: { params: Promise<{ id: s
             open={dialogOpen}
             onOpenChange={(open) => {
               setDialogOpen(open);
-              if (!open) setEditingItem(null);
+              if (!open) {
+                setEditingItem(null);
+              }
             }}
           >
             <DialogTrigger

--- a/apps/frontend/app/(admin)/admin/editions/page.tsx
+++ b/apps/frontend/app/(admin)/admin/editions/page.tsx
@@ -3,13 +3,7 @@
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { DataTable } from '@/components/common/DataTable';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -18,13 +12,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Textarea } from '@/components/ui/textarea';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { s3Put } from '@/lib/utils/file';
-import { useForm } from '@tanstack/react-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { EditionFormDialog } from '@/features/admin/editions/EditionFormDialog';
+import {
+  useChangeEditionStatusMutation,
+  useDeleteEditionMutation,
+  useUploadEditionRuleMutation,
+} from '@/features/admin/editions/mutations';
+import { useAdminEditionsList } from '@/features/admin/editions/query';
+import { SHARING_STATUS_LABELS } from '@/features/admin/editions/types';
+import type { Edition, SharingStatus } from '@/features/admin/editions/types';
 import type { ColumnDef } from '@tanstack/react-table';
 import {
   LayoutListIcon,
@@ -37,30 +33,6 @@ import {
 import Link from 'next/link';
 import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
 import { useRef, useState } from 'react';
-import { toast } from 'sonner';
-import { z } from 'zod';
-
-const SHARING_STATUS_LABELS: Record<Edition['sharingStatus'], string> = {
-  draft: '準備中',
-  accepting: '受付中',
-  sharing: '共有中',
-  closed: '締切後',
-};
-
-type Edition = {
-  id: string;
-  seriesId: string;
-  year: number;
-  name: string;
-  description: string | null;
-  ruleDocuments: { label: string; s3_key: string; mime_type: string; url: string }[] | null;
-  sharingStatus: 'draft' | 'accepting' | 'sharing' | 'closed';
-  externalLinks: { label: string; url: string }[] | null;
-  createdAt: unknown;
-  updatedAt: unknown;
-};
-
-type ExternalLink = { label: string; url: string };
 
 const paginationParsers = {
   page: parseAsInteger.withDefault(1),
@@ -68,327 +40,28 @@ const paginationParsers = {
   q: parseAsString.withDefault(''),
 };
 
-function EditionFormDialog({ editing, onClose }: { editing: Edition | null; onClose: () => void }) {
-  const queryClient = useQueryClient();
-  const [externalLinks, setExternalLinks] = useState<ExternalLink[]>(editing?.externalLinks ?? []);
-
-  const { data: seriesData } = useQuery({
-    queryKey: ['series-all'],
-    queryFn: async () => {
-      const r = await apiClient.GET('/api/series', { params: { query: { pageSize: 100 } } });
-      return throwIfError(r);
-    },
-  });
-
-  const form = useForm({
-    defaultValues: {
-      seriesId: editing?.seriesId ?? '',
-      year: editing?.year ?? new Date().getFullYear(),
-      name: editing?.name ?? '',
-      description: editing?.description ?? '',
-      sharingStatus: (editing?.sharingStatus ?? 'draft') as
-        | 'draft'
-        | 'accepting'
-        | 'sharing'
-        | 'closed',
-    },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  const mutation = useMutation({
-    mutationFn: async (values: {
-      seriesId: string;
-      year: number;
-      name: string;
-      description: string;
-      sharingStatus: 'draft' | 'accepting' | 'sharing' | 'closed';
-    }) => {
-      const body = {
-        seriesId: values.seriesId,
-        year: values.year,
-        name: values.name,
-        description: values.description,
-        sharingStatus: values.sharingStatus,
-        externalLinks: externalLinks.length ? externalLinks : undefined,
-      };
-      if (editing) {
-        const r = await apiClient.PUT('/api/admin/editions/{id}', {
-          params: { path: { id: editing.id } },
-          body,
-        });
-        return throwIfError(r);
-      }
-      const r = await apiClient.POST('/api/admin/editions', { body });
-      return throwIfError(r);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'editions'] });
-      queryClient.invalidateQueries({ queryKey: ['editions'] });
-      toast.success(editing ? '更新しました' : '作成しました');
-      onClose();
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const series = seriesData?.data ?? [];
-
-  const updateLink = (i: number, field: keyof ExternalLink, value: string) => {
-    setExternalLinks((prev) => prev.map((l, idx) => (idx === i ? { ...l, [field]: value } : l)));
-  };
-
-  const removeLink = (i: number) => {
-    setExternalLinks((prev) => prev.filter((_, idx) => idx !== i));
-  };
-
-  return (
-    <DialogContent className='max-w-lg max-h-[80vh] overflow-y-auto'>
-      <DialogHeader>
-        <DialogTitle>{editing ? '大会回を編集' : '新規大会回作成'}</DialogTitle>
-      </DialogHeader>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          form.handleSubmit();
-        }}
-        className='space-y-4'
-      >
-        <form.Field
-          name='seriesId'
-          validators={{ onChange: z.string().min(1, 'シリーズを選択してください') }}
-        >
-          {(field) => (
-            <div className='space-y-1'>
-              <span className='text-sm font-medium'>シリーズ *</span>
-              <Select value={field.state.value} onValueChange={(v) => field.handleChange(v ?? '')}>
-                <SelectTrigger>
-                  <SelectValue placeholder='選択...'>
-                    {series.find((item) => item.id === field.state.value)?.name}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {series.map((s) => (
-                    <SelectItem key={s.id} value={s.id}>
-                      {s.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {field.state.meta.errors[0] && (
-                <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
-              )}
-            </div>
-          )}
-        </form.Field>
-        <div className='flex gap-3'>
-          <form.Field name='year' validators={{ onChange: z.number().int().min(2000) }}>
-            {(field) => (
-              <div className='space-y-1 w-24'>
-                <label htmlFor={field.name} className='text-sm font-medium'>
-                  年度 *
-                </label>
-                <Input
-                  id={field.name}
-                  type='number'
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(Number(e.target.value))}
-                />
-              </div>
-            )}
-          </form.Field>
-          <form.Field
-            name='name'
-            validators={{ onChange: z.string().min(1, '名称を入力してください') }}
-          >
-            {(field) => (
-              <div className='space-y-1 flex-1'>
-                <label htmlFor={field.name} className='text-sm font-medium'>
-                  名称 *
-                </label>
-                <Input
-                  id={field.name}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-                {field.state.meta.errors[0] && (
-                  <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
-                )}
-              </div>
-            )}
-          </form.Field>
-        </div>
-        <form.Field name='description'>
-          {(field) => (
-            <div className='space-y-1'>
-              <label htmlFor={field.name} className='text-sm font-medium'>
-                説明
-              </label>
-              <Textarea
-                id={field.name}
-                rows={2}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-            </div>
-          )}
-        </form.Field>
-        <form.Field name='sharingStatus'>
-          {(field) => (
-            <div className='space-y-1'>
-              <span className='text-sm font-medium'>共有状態</span>
-              <Select
-                value={field.state.value}
-                onValueChange={(v) =>
-                  field.handleChange(v as 'draft' | 'accepting' | 'sharing' | 'closed')
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue>{SHARING_STATUS_LABELS[field.state.value]}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value='draft'>準備中</SelectItem>
-                  <SelectItem value='accepting'>受付中</SelectItem>
-                  <SelectItem value='sharing'>共有中</SelectItem>
-                  <SelectItem value='closed'>締切後</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-        </form.Field>
-        <div className='space-y-2'>
-          <p className='text-sm font-medium'>外部リンク</p>
-          {externalLinks.map((link, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: dynamic list
-            <div key={i} className='flex gap-2'>
-              <Input
-                placeholder='ラベル'
-                value={link.label}
-                onChange={(e) => updateLink(i, 'label', e.target.value)}
-                className='w-24'
-              />
-              <Input
-                placeholder='URL'
-                value={link.url}
-                onChange={(e) => updateLink(i, 'url', e.target.value)}
-                className='flex-1'
-              />
-              <Button type='button' variant='ghost' size='sm' onClick={() => removeLink(i)}>
-                <Trash2Icon className='h-3 w-3' />
-              </Button>
-            </div>
-          ))}
-          <Button
-            type='button'
-            variant='outline'
-            size='sm'
-            onClick={() => setExternalLinks((prev) => [...prev, { label: '', url: '' }])}
-          >
-            <PlusIcon className='h-3 w-3 mr-1' />
-            追加
-          </Button>
-        </div>
-        <div className='flex justify-end gap-2'>
-          <Button type='button' variant='ghost' onClick={onClose}>
-            キャンセル
-          </Button>
-          <Button type='submit' disabled={mutation.isPending}>
-            {editing ? '更新' : '作成'}
-          </Button>
-        </div>
-      </form>
-    </DialogContent>
-  );
-}
-
 export default function AdminEditionsPage() {
-  const queryClient = useQueryClient();
   const [queryParams, setQueryParams] = useQueryStates(paginationParsers);
   const [editingItem, setEditingItem] = useState<Edition | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const ruleFileInputRef = useRef<HTMLInputElement>(null);
   const [uploadingEditionId, setUploadingEditionId] = useState<string | null>(null);
 
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.editions(queryParams),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/editions', {
-        params: {
-          query: {
-            page: queryParams.page,
-            pageSize: queryParams.pageSize,
-            q: queryParams.q || undefined,
-          },
-        },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const result = await apiClient.DELETE('/api/admin/editions/{id}', {
-        params: { path: { id } },
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'editions'] });
-      queryClient.invalidateQueries({ queryKey: ['editions'] });
-      toast.success('削除しました');
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const changeStatusMutation = useMutation({
-    mutationFn: async ({ id, status }: { id: string; status: string }) => {
-      const result = await apiClient.PUT('/api/admin/editions/{id}/status', {
-        params: { path: { id } },
-        body: { sharingStatus: status as 'draft' | 'accepting' | 'sharing' | 'closed' },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'editions'] });
-      queryClient.invalidateQueries({ queryKey: ['editions'] });
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
+  const { data, isLoading } = useAdminEditionsList(queryParams);
+  const deleteMutation = useDeleteEditionMutation();
+  const changeStatusMutation = useChangeEditionStatusMutation();
+  const uploadRuleMutation = useUploadEditionRuleMutation();
 
   const handleRuleUpload = async (editionId: string, file: File) => {
+    const edition = data?.data.find((item) => item.id === editionId);
+    const existingDocs = (edition?.ruleDocuments ?? []).map((document) => ({
+      label: document.label,
+      s3_key: document.s3_key,
+      mime_type: document.mime_type,
+    }));
+
     try {
-      const presignResult = await apiClient.POST('/api/admin/editions/{id}/rules/presign', {
-        params: { path: { id: editionId } },
-        body: { fileName: file.name, contentType: file.type },
-      });
-      const presign = throwIfError(presignResult);
-      await s3Put(presign.data.presignedUrl, file);
-
-      const edition = data?.data.find((e) => e.id === editionId);
-      const existingDocs = (edition?.ruleDocuments ?? []).map((d) => ({
-        label: d.label,
-        s3_key: d.s3_key,
-        mime_type: d.mime_type,
-      }));
-
-      await apiClient.PUT('/api/admin/editions/{id}/rules', {
-        params: { path: { id: editionId } },
-        body: {
-          ruleDocuments: [
-            ...existingDocs,
-            { label: file.name, s3_key: presign.data.s3Key, mime_type: file.type },
-          ],
-        },
-      });
-
-      queryClient.invalidateQueries({ queryKey: ['admin', 'editions'] });
-      queryClient.invalidateQueries({ queryKey: ['editions'] });
-      toast.success('ルール資料をアップロードしました');
-    } catch (err) {
-      toast.error(getApiErrorMessage(err));
+      await uploadRuleMutation.mutateAsync({ editionId, file, existingDocuments: existingDocs });
     } finally {
       setUploadingEditionId(null);
     }
@@ -407,7 +80,7 @@ export default function AdminEditionsPage() {
           onValueChange={(status) =>
             changeStatusMutation.mutate({
               id: row.original.id,
-              status: status ?? row.original.sharingStatus,
+              status: (status ?? row.original.sharingStatus) as SharingStatus,
             })
           }
         >
@@ -486,10 +159,12 @@ export default function AdminEditionsPage() {
         type='file'
         className='hidden'
         accept='.pdf'
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file && uploadingEditionId) handleRuleUpload(uploadingEditionId, file);
-          e.target.value = '';
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file && uploadingEditionId) {
+            void handleRuleUpload(uploadingEditionId, file);
+          }
+          event.target.value = '';
         }}
       />
       <div className='flex items-center justify-between gap-3 flex-wrap'>
@@ -498,14 +173,16 @@ export default function AdminEditionsPage() {
           <Input
             placeholder='検索...'
             defaultValue={queryParams.q}
-            onChange={(e) => setQueryParams({ q: e.target.value, page: 1 })}
+            onChange={(event) => setQueryParams({ q: event.target.value, page: 1 })}
             className='max-w-48'
           />
           <Dialog
             open={dialogOpen}
             onOpenChange={(open) => {
               setDialogOpen(open);
-              if (!open) setEditingItem(null);
+              if (!open) {
+                setEditingItem(null);
+              }
             }}
           >
             <DialogTrigger

--- a/apps/frontend/app/(admin)/admin/series/page.tsx
+++ b/apps/frontend/app/(admin)/admin/series/page.tsx
@@ -4,37 +4,16 @@ import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { DataTable } from '@/components/common/DataTable';
 import { DateTimeDisplay } from '@/components/common/DateTimeDisplay';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { useForm } from '@tanstack/react-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { SeriesFormDialog } from '@/features/admin/series/SeriesFormDialog';
+import { useDeleteSeriesMutation } from '@/features/admin/series/mutations';
+import { useAdminSeriesList } from '@/features/admin/series/query';
+import type { Series } from '@/features/admin/series/types';
 import type { ColumnDef } from '@tanstack/react-table';
 import { PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
 import { useState } from 'react';
-import { toast } from 'sonner';
-import { z } from 'zod';
-
-type Series = {
-  id: string;
-  name: string;
-  description: string | null;
-  externalLinks: { label: string; url: string }[] | null;
-  createdAt: unknown;
-  updatedAt: unknown;
-};
-
-type ExternalLink = { label: string; url: string };
 
 const paginationParsers = {
   page: parseAsInteger.withDefault(1),
@@ -42,192 +21,13 @@ const paginationParsers = {
   q: parseAsString.withDefault(''),
 };
 
-function SeriesFormDialog({
-  editing,
-  onClose,
-}: {
-  editing: Series | null;
-  onClose: () => void;
-}) {
-  const queryClient = useQueryClient();
-  const [externalLinks, setExternalLinks] = useState<ExternalLink[]>(editing?.externalLinks ?? []);
-
-  const form = useForm({
-    defaultValues: {
-      name: editing?.name ?? '',
-      description: editing?.description ?? '',
-    },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  const mutation = useMutation({
-    mutationFn: async (values: { name: string; description: string }) => {
-      const body = {
-        name: values.name,
-        description: values.description,
-        externalLinks: externalLinks.length ? externalLinks : undefined,
-      };
-      if (editing) {
-        const r = await apiClient.PUT('/api/admin/series/{id}', {
-          params: { path: { id: editing.id } },
-          body,
-        });
-        return throwIfError(r);
-      }
-      const r = await apiClient.POST('/api/admin/series', { body });
-      return throwIfError(r);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'series'] });
-      queryClient.invalidateQueries({ queryKey: ['series'] });
-      queryClient.invalidateQueries({ queryKey: ['series-all'] });
-      toast.success(editing ? '更新しました' : '作成しました');
-      onClose();
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const updateLink = (i: number, field: keyof ExternalLink, value: string) => {
-    setExternalLinks((prev) => prev.map((l, idx) => (idx === i ? { ...l, [field]: value } : l)));
-  };
-
-  const removeLink = (i: number) => {
-    setExternalLinks((prev) => prev.filter((_, idx) => idx !== i));
-  };
-
-  return (
-    <DialogContent>
-      <DialogHeader>
-        <DialogTitle>{editing ? 'シリーズを編集' : '新規シリーズ作成'}</DialogTitle>
-      </DialogHeader>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          form.handleSubmit();
-        }}
-        className='space-y-4'
-      >
-        <form.Field
-          name='name'
-          validators={{ onChange: z.string().min(1, '名称を入力してください') }}
-        >
-          {(field) => (
-            <div className='space-y-1'>
-              <label htmlFor={field.name} className='text-sm font-medium'>
-                名称 *
-              </label>
-              <Input
-                id={field.name}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-              {field.state.meta.errors[0] && (
-                <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
-              )}
-            </div>
-          )}
-        </form.Field>
-        <form.Field name='description'>
-          {(field) => (
-            <div className='space-y-1'>
-              <label htmlFor={field.name} className='text-sm font-medium'>
-                説明
-              </label>
-              <Textarea
-                id={field.name}
-                rows={2}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-              />
-            </div>
-          )}
-        </form.Field>
-        <div className='space-y-2'>
-          <p className='text-sm font-medium'>外部リンク</p>
-          {externalLinks.map((link, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: dynamic list
-            <div key={i} className='flex gap-2'>
-              <Input
-                placeholder='ラベル'
-                value={link.label}
-                onChange={(e) => updateLink(i, 'label', e.target.value)}
-                className='w-24'
-              />
-              <Input
-                placeholder='URL'
-                value={link.url}
-                onChange={(e) => updateLink(i, 'url', e.target.value)}
-                className='flex-1'
-              />
-              <Button type='button' variant='ghost' size='sm' onClick={() => removeLink(i)}>
-                <Trash2Icon className='h-3 w-3' />
-              </Button>
-            </div>
-          ))}
-          <Button
-            type='button'
-            variant='outline'
-            size='sm'
-            onClick={() => setExternalLinks((prev) => [...prev, { label: '', url: '' }])}
-          >
-            <PlusIcon className='h-3 w-3 mr-1' />
-            リンクを追加
-          </Button>
-        </div>
-        <div className='flex justify-end gap-2'>
-          <Button type='button' variant='ghost' onClick={onClose}>
-            キャンセル
-          </Button>
-          <Button type='submit' disabled={mutation.isPending}>
-            {editing ? '更新' : '作成'}
-          </Button>
-        </div>
-      </form>
-    </DialogContent>
-  );
-}
-
 export default function AdminSeriesPage() {
-  const queryClient = useQueryClient();
   const [queryParams, setQueryParams] = useQueryStates(paginationParsers);
   const [editingItem, setEditingItem] = useState<Series | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.series(queryParams),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/series', {
-        params: {
-          query: {
-            page: queryParams.page,
-            pageSize: queryParams.pageSize,
-            q: queryParams.q || undefined,
-          },
-        },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const result = await apiClient.DELETE('/api/admin/series/{id}', {
-        params: { path: { id } },
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['admin', 'series'] });
-      queryClient.invalidateQueries({ queryKey: ['series'] });
-      queryClient.invalidateQueries({ queryKey: ['series-all'] });
-      toast.success('削除しました');
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
+  const { data, isLoading } = useAdminSeriesList(queryParams);
+  const deleteMutation = useDeleteSeriesMutation();
 
   const columns: ColumnDef<Series>[] = [
     { header: '名称', accessorKey: 'name' },
@@ -276,14 +76,16 @@ export default function AdminSeriesPage() {
           <Input
             placeholder='検索...'
             defaultValue={queryParams.q}
-            onChange={(e) => setQueryParams({ q: e.target.value, page: 1 })}
+            onChange={(event) => setQueryParams({ q: event.target.value, page: 1 })}
             className='max-w-48'
           />
           <Dialog
             open={dialogOpen}
             onOpenChange={(open) => {
               setDialogOpen(open);
-              if (!open) setEditingItem(null);
+              if (!open) {
+                setEditingItem(null);
+              }
             }}
           >
             <DialogTrigger

--- a/apps/frontend/app/(admin)/admin/universities/page.tsx
+++ b/apps/frontend/app/(admin)/admin/universities/page.tsx
@@ -10,51 +10,17 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { useForm } from '@tanstack/react-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type University,
+  useAdminUniversitiesList,
+  useCreateUniversityForm,
+} from '@/features/admin/universities/hooks';
 import type { ColumnDef } from '@tanstack/react-table';
 import { PlusIcon } from 'lucide-react';
 import { useState } from 'react';
-import { toast } from 'sonner';
-import { z } from 'zod';
-
-type University = {
-  id: string;
-  name: string;
-  slug: string;
-  createdAt: unknown;
-};
 
 function CreateUniversityDialog({ onClose }: { onClose: () => void }) {
-  const queryClient = useQueryClient();
-  const form = useForm({
-    defaultValues: { name: '', slug: '', ownerEmail: '' },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync(value);
-    },
-  });
-
-  const mutation = useMutation({
-    mutationFn: async (values: { name: string; slug: string; ownerEmail: string }) => {
-      const r = await apiClient.POST('/api/admin/universities', {
-        body: {
-          name: values.name,
-          slug: values.slug,
-          ownerEmail: values.ownerEmail || undefined,
-        },
-      });
-      return throwIfError(r);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.universities({}) });
-      toast.success('大学を作成しました');
-      onClose();
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
+  const { form, mutation, validators } = useCreateUniversityForm(onClose);
 
   return (
     <DialogContent>
@@ -68,10 +34,7 @@ function CreateUniversityDialog({ onClose }: { onClose: () => void }) {
         }}
         className='space-y-4'
       >
-        <form.Field
-          name='name'
-          validators={{ onChange: z.string().min(1, '名称を入力してください') }}
-        >
+        <form.Field name='name' validators={{ onChange: validators.name }}>
           {(field) => (
             <div className='space-y-1'>
               <label htmlFor={field.name} className='text-sm font-medium'>
@@ -90,15 +53,7 @@ function CreateUniversityDialog({ onClose }: { onClose: () => void }) {
             </div>
           )}
         </form.Field>
-        <form.Field
-          name='slug'
-          validators={{
-            onChange: z
-              .string()
-              .min(1, 'スラッグを入力してください')
-              .regex(/^[a-z0-9-]+$/, '半角英数字とハイフンのみ使用できます'),
-          }}
-        >
+        <form.Field name='slug' validators={{ onChange: validators.slug }}>
           {(field) => (
             <div className='space-y-1'>
               <label htmlFor={field.name} className='text-sm font-medium'>
@@ -117,12 +72,7 @@ function CreateUniversityDialog({ onClose }: { onClose: () => void }) {
             </div>
           )}
         </form.Field>
-        <form.Field
-          name='ownerEmail'
-          validators={{
-            onChange: z.string().email('有効なメールアドレスを入力してください').or(z.literal('')),
-          }}
-        >
+        <form.Field name='ownerEmail' validators={{ onChange: validators.ownerEmail }}>
           {(field) => (
             <div className='space-y-1'>
               <label htmlFor={field.name} className='text-sm font-medium'>
@@ -157,16 +107,7 @@ function CreateUniversityDialog({ onClose }: { onClose: () => void }) {
 
 export default function AdminUniversitiesPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
-
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.universities({}),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/admin/universities', {
-        params: { query: { pageSize: 100 } },
-      });
-      return throwIfError(result);
-    },
-  });
+  const { data, isLoading } = useAdminUniversitiesList();
 
   const columns: ColumnDef<University>[] = [
     { header: '名称', accessorKey: 'name' },

--- a/apps/frontend/app/(admin)/admin/users/page.tsx
+++ b/apps/frontend/app/(admin)/admin/users/page.tsx
@@ -15,39 +15,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type AdminUser,
+  useAdminUsersPageState,
+  useMembershipDialog,
+} from '@/features/admin/users/hooks';
 import type { ColumnDef } from '@tanstack/react-table';
-import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
-import { useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
-
-type AdminUser = {
-  id: string;
-  name: string;
-  email: string;
-  isAdmin: boolean;
-  createdAt: unknown;
-  organizationCount: number;
-};
-
-type Membership = {
-  memberId: string;
-  organizationId: string;
-  organizationName: string;
-  organizationSlug: string;
-  role: 'owner' | 'member';
-  createdAt: unknown;
-};
-
-const listParsers = {
-  page: parseAsInteger.withDefault(1),
-  pageSize: parseAsInteger.withDefault(20),
-  q: parseAsString.withDefault(''),
-  sort: parseAsString.withDefault('createdAt:desc'),
-};
 
 function MembershipDialog({
   user,
@@ -58,116 +31,17 @@ function MembershipDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const queryClient = useQueryClient();
-  const [selectedOrganizationId, setSelectedOrganizationId] = useState('');
-  const [selectedRole, setSelectedRole] = useState<'owner' | 'member'>('member');
-
-  useEffect(() => {
-    if (!open) {
-      setSelectedOrganizationId('');
-      setSelectedRole('member');
-    }
-  }, [open]);
-
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.userMemberships(user?.id ?? ''),
-    queryFn: async () => {
-      if (!user) {
-        return null;
-      }
-      const result = await apiClient.GET('/api/admin/users/{userId}/memberships', {
-        params: { path: { userId: user.id } },
-      });
-      return throwIfError(result);
-    },
-    enabled: open && !!user,
-  });
-
-  const invalidateTargets = async () => {
-    if (!user) {
-      return;
-    }
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.userMemberships(user.id) }),
-      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] }),
-      queryClient.invalidateQueries({ queryKey: ['university', 'members'] }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.me }),
-    ]);
-  };
-
-  const createMutation = useMutation({
-    mutationFn: async () => {
-      if (!user || !selectedOrganizationId) {
-        return;
-      }
-      const result = await apiClient.POST('/api/admin/users/{userId}/memberships', {
-        params: { path: { userId: user.id } },
-        body: {
-          organizationId: selectedOrganizationId,
-          role: selectedRole,
-        },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: async () => {
-      toast.success('所属を追加しました');
-      setSelectedOrganizationId('');
-      setSelectedRole('member');
-      await invalidateTargets();
-    },
-    onError: (error) => {
-      const message =
-        error instanceof ApiError && error.status === 409
-          ? getApiErrorMessage(error, 'duplicate')
-          : getApiErrorMessage(error);
-      toast.error(message);
-    },
-  });
-
-  const changeRoleMutation = useMutation({
-    mutationFn: async ({ memberId, role }: { memberId: string; role: 'owner' | 'member' }) => {
-      const result = await apiClient.PUT('/api/admin/memberships/{memberId}/role', {
-        params: { path: { memberId } },
-        body: { role },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: async () => {
-      toast.success('ロールを更新しました');
-      await invalidateTargets();
-    },
-    onError: (error) => {
-      const message =
-        error instanceof ApiError && error.status === 409
-          ? getApiErrorMessage(error, 'last-owner')
-          : getApiErrorMessage(error);
-      toast.error(message);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (memberId: string) => {
-      const result = await apiClient.DELETE('/api/admin/memberships/{memberId}', {
-        params: { path: { memberId } },
-      });
-      if (!result.response.ok) {
-        throw new ApiError(result.response.status, result.error);
-      }
-    },
-    onSuccess: async () => {
-      toast.success('所属を解除しました');
-      await invalidateTargets();
-    },
-    onError: (error) => {
-      const message =
-        error instanceof ApiError && error.status === 409
-          ? getApiErrorMessage(error, 'last-owner')
-          : getApiErrorMessage(error);
-      toast.error(message);
-    },
-  });
-
-  const memberships = (data?.data ?? []) as Membership[];
+  const {
+    memberships,
+    isLoading,
+    selectedOrganizationId,
+    setSelectedOrganizationId,
+    selectedRole,
+    setSelectedRole,
+    createMutation,
+    changeRoleMutation,
+    deleteMutation,
+  } = useMembershipDialog(user, open);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -273,44 +147,17 @@ function MembershipDialog({
 }
 
 export default function AdminUsersPage() {
-  const [queryParams, setQueryParams] = useQueryStates(listParsers);
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
-
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.admin.users(queryParams),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/admin/users', {
-        params: {
-          query: {
-            page: queryParams.page,
-            pageSize: queryParams.pageSize,
-            q: queryParams.q || undefined,
-            sort: queryParams.sort as
-              | 'name:asc'
-              | 'name:desc'
-              | 'email:asc'
-              | 'email:desc'
-              | 'createdAt:asc'
-              | 'createdAt:desc',
-          },
-        },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const sortOptions = useMemo(
-    () => [
-      { value: 'createdAt:desc', label: '作成日 新しい順' },
-      { value: 'createdAt:asc', label: '作成日 古い順' },
-      { value: 'name:asc', label: '名前 昇順' },
-      { value: 'name:desc', label: '名前 降順' },
-      { value: 'email:asc', label: 'メール 昇順' },
-      { value: 'email:desc', label: 'メール 降順' },
-    ],
-    [],
-  );
+  const {
+    queryParams,
+    setQueryParams,
+    dialogOpen,
+    setDialogOpen,
+    selectedUser,
+    setSelectedUser,
+    data,
+    isLoading,
+    sortOptions,
+  } = useAdminUsersPageState();
 
   const columns: ColumnDef<AdminUser>[] = [
     {

--- a/apps/frontend/app/(authenticated)/account/settings/page.tsx
+++ b/apps/frontend/app/(authenticated)/account/settings/page.tsx
@@ -3,62 +3,17 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { useAuth, useInvalidateMe } from '@/contexts/AuthContext';
-import { authClient } from '@/lib/auth/client';
-import { useForm } from '@tanstack/react-form';
-import { useMutation } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { z } from 'zod';
+import { useAccountSettingsForms } from '@/features/account/settings/hooks';
 
 export default function AccountSettingsPage() {
-  const { user } = useAuth();
-  const invalidateMe = useInvalidateMe();
-
-  const profileForm = useForm({
-    defaultValues: { name: user?.name ?? '' },
-    onSubmit: async ({ value }) => {
-      await updateProfileMutation.mutateAsync(value);
-    },
-  });
-
-  const passwordForm = useForm({
-    defaultValues: { currentPassword: '', newPassword: '', confirmPassword: '' },
-    onSubmit: async ({ value }) => {
-      await changePasswordMutation.mutateAsync(value);
-    },
-  });
-
-  const updateProfileMutation = useMutation({
-    mutationFn: async (values: { name: string }) => {
-      const result = await authClient.updateUser({ name: values.name });
-      if (result.error) throw new Error(result.error.message);
-    },
-    onSuccess: async () => {
-      await invalidateMe();
-      toast.success('プロフィールを更新しました');
-    },
-    onError: (err) => toast.error(err instanceof Error ? err.message : '更新に失敗しました'),
-  });
-
-  const changePasswordMutation = useMutation({
-    mutationFn: async (values: {
-      currentPassword: string;
-      newPassword: string;
-      confirmPassword: string;
-    }) => {
-      const result = await authClient.changePassword({
-        currentPassword: values.currentPassword,
-        newPassword: values.newPassword,
-      });
-      if (result.error) throw new Error(result.error.message);
-    },
-    onSuccess: () => {
-      passwordForm.reset();
-      toast.success('パスワードを変更しました');
-    },
-    onError: (err) =>
-      toast.error(err instanceof Error ? err.message : 'パスワード変更に失敗しました'),
-  });
+  const {
+    user,
+    profileForm,
+    passwordForm,
+    updateProfileMutation,
+    changePasswordMutation,
+    validators,
+  } = useAccountSettingsForms();
 
   return (
     <div className='space-y-8 max-w-xl'>
@@ -77,10 +32,7 @@ export default function AccountSettingsPage() {
             className='space-y-4'
           >
             <div className='text-sm text-muted-foreground'>メールアドレス: {user?.email}</div>
-            <profileForm.Field
-              name='name'
-              validators={{ onChange: z.string().min(1, '名前を入力してください') }}
-            >
+            <profileForm.Field name='name' validators={{ onChange: validators.profileName }}>
               {(field) => (
                 <div className='space-y-1'>
                   <label htmlFor={field.name} className='text-sm font-medium'>
@@ -119,7 +71,7 @@ export default function AccountSettingsPage() {
           >
             <passwordForm.Field
               name='currentPassword'
-              validators={{ onChange: z.string().min(1, '現在のパスワードを入力してください') }}
+              validators={{ onChange: validators.currentPassword }}
             >
               {(field) => (
                 <div className='space-y-1'>
@@ -141,9 +93,7 @@ export default function AccountSettingsPage() {
             </passwordForm.Field>
             <passwordForm.Field
               name='newPassword'
-              validators={{
-                onChange: z.string().min(8, '新しいパスワードは8文字以上で入力してください'),
-              }}
+              validators={{ onChange: validators.newPassword }}
             >
               {(field) => (
                 <div className='space-y-1'>
@@ -168,10 +118,10 @@ export default function AccountSettingsPage() {
               validators={{
                 onChangeListenTo: ['newPassword'],
                 onChange: ({ value, fieldApi }) => {
-                  if (value !== fieldApi.form.getFieldValue('newPassword')) {
-                    return { message: 'パスワードが一致しません' };
-                  }
-                  return undefined;
+                  return validators.confirmPassword({
+                    value,
+                    newPassword: fieldApi.form.getFieldValue('newPassword'),
+                  });
                 },
               }}
             >

--- a/apps/frontend/app/(authenticated)/dashboard/page.tsx
+++ b/apps/frontend/app/(authenticated)/dashboard/page.tsx
@@ -5,51 +5,11 @@ import { StatusBadge } from '@/components/common/StatusBadge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useOrganization } from '@/contexts/OrganizationContext';
-import { apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useDashboardData } from '@/features/dashboard/query';
 import Link from 'next/link';
 
 export default function DashboardPage() {
-  const { organizationId, currentOrg } = useOrganization();
-
-  // Fetch all non-draft editions
-  const { data: editionsData, isLoading: editionsLoading } = useQuery({
-    queryKey: queryKeys.editions.all({ pageSize: 50 }),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/editions', {
-        params: { query: { pageSize: 50 } },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const editions = editionsData?.data ?? [];
-
-  // Fetch my-submission-status for each edition (parallel)
-  const statusQueries = useQueries({
-    queries: editions.map((edition) => ({
-      queryKey: queryKeys.editions.mySubmissionStatus(edition.id, organizationId ?? ''),
-      queryFn: async () => {
-        if (!organizationId) return null;
-        const result = await apiClient.GET('/api/editions/{id}/my-submission-status', {
-          params: { path: { id: edition.id } },
-          headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-        });
-        if (result.response.status === 403 || result.response.status === 404) return null;
-        return throwIfError(result);
-      },
-      enabled: !!organizationId,
-    })),
-  });
-
-  // Filter editions where my university has participations
-  const myEditions = editions
-    .map((edition, i) => ({ edition, status: statusQueries[i]?.data }))
-    .filter(({ status }) => status && (status.data?.participations?.length ?? 0) > 0);
-
-  const isLoading = editionsLoading || statusQueries.some((q) => q.isLoading);
+  const { organizationId, currentOrg, myEditions, isLoading } = useDashboardData();
 
   if (!organizationId && !isLoading) {
     return (

--- a/apps/frontend/app/(authenticated)/editions/[id]/submissions/[submissionId]/history/page.tsx
+++ b/apps/frontend/app/(authenticated)/editions/[id]/submissions/[submissionId]/history/page.tsx
@@ -4,10 +4,11 @@ import { DataTable } from '@/components/common/DataTable';
 import { DateTimeDisplay } from '@/components/common/DateTimeDisplay';
 import { Button } from '@/components/ui/button';
 import { useOrganization } from '@/contexts/OrganizationContext';
+import {
+  type SubmissionHistoryRow,
+  useSubmissionHistory,
+} from '@/features/editions/submission-history/hooks';
 import { apiClient, throwIfError } from '@/lib/api/client';
-import type { paths } from '@/lib/api/schema';
-import { queryKeys } from '@/lib/query/keys';
-import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { DownloadIcon, ExternalLinkIcon } from 'lucide-react';
 import { parseAsInteger, useQueryStates } from 'nuqs';
@@ -18,11 +19,6 @@ const paginationParsers = {
   pageSize: parseAsInteger.withDefault(20),
 };
 
-type SubmissionHistoryPath = paths['/api/submissions/{id}/history'];
-type SubmissionHistoryResponse =
-  SubmissionHistoryPath['get']['responses'][200]['content']['application/json'];
-type HistoryRow = SubmissionHistoryResponse['data'][number];
-
 export default function SubmissionHistoryPage({
   params,
 }: {
@@ -32,19 +28,7 @@ export default function SubmissionHistoryPage({
   const { organizationId } = useOrganization();
   const [queryParams, setQueryParams] = useQueryStates(paginationParsers);
 
-  const { data, isLoading } = useQuery<SubmissionHistoryResponse>({
-    queryKey: queryKeys.submissions.history(submissionId, organizationId ?? '', queryParams),
-    queryFn: async (): Promise<SubmissionHistoryResponse> => {
-      const result = await apiClient.GET('/api/submissions/{id}/history', {
-        params: {
-          path: { id: submissionId },
-          query: { page: queryParams.page, pageSize: queryParams.pageSize },
-        },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      return throwIfError(result);
-    },
-  });
+  const { data, isLoading } = useSubmissionHistory(submissionId, organizationId, queryParams);
 
   const historyRows = data?.data ?? [];
 
@@ -57,7 +41,7 @@ export default function SubmissionHistoryPage({
     window.open(data.data.presignedUrl, '_blank');
   };
 
-  const columns: ColumnDef<HistoryRow>[] = [
+  const columns: ColumnDef<SubmissionHistoryRow>[] = [
     { header: 'バージョン', cell: ({ row }) => `v${row.original.version}` },
     {
       header: '更新者',

--- a/apps/frontend/app/(authenticated)/editions/[id]/submit/page.tsx
+++ b/apps/frontend/app/(authenticated)/editions/[id]/submit/page.tsx
@@ -10,63 +10,34 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useAuth } from '@/contexts/AuthContext';
-import { useOrganization } from '@/contexts/OrganizationContext';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { s3Put, validateFile } from '@/lib/utils/file';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type StatusItem,
+  type TemplateItem,
+  useSubmitPageData,
+  useTemplateSubmissionMutations,
+} from '@/features/editions/submit/hooks';
 import { ExternalLinkIcon, HistoryIcon, Trash2Icon, UploadIcon } from 'lucide-react';
 import Link from 'next/link';
 import { use, useRef, useState } from 'react';
-import { toast } from 'sonner';
 
 export default function SubmitPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { user } = useAuth();
-  const { organizationId, currentOrg } = useOrganization();
-  const queryClient = useQueryClient();
-  const [selectedParticipationId, setSelectedParticipationId] = useState<string | null>(null);
-
-  const { data: editionData, isLoading: isEditionLoading } = useQuery({
-    queryKey: queryKeys.editions.detail(id),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/editions/{id}', {
-        params: { path: { id } },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.editions.mySubmissionStatus(id, organizationId ?? ''),
-    queryFn: async () => {
-      if (!organizationId) return null;
-      const result = await apiClient.GET('/api/editions/{id}/my-submission-status', {
-        params: { path: { id } },
-        headers: { 'X-Organization-Id': organizationId },
-      });
-      return throwIfError(result);
-    },
-    enabled: !!organizationId,
-  });
-
-  const statusData = data?.data;
-  const participations = statusData?.participations ?? [];
-  const templates = statusData?.templates ?? [];
-  const items = statusData?.items ?? [];
-  const sharingStatus = statusData?.edition?.sharingStatus;
-  const edition = editionData?.data;
-
-  const activeParticipationId =
-    participations.length === 1 ? (participations[0]?.id ?? null) : selectedParticipationId;
-
-  const invalidateStatus = () => {
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.editions.mySubmissionStatus(id, organizationId ?? ''),
-    });
-  };
+  const {
+    user,
+    organizationId,
+    selectedParticipationId,
+    setSelectedParticipationId,
+    isEditionLoading,
+    isLoading,
+    statusData,
+    participations,
+    templates,
+    items,
+    sharingStatus,
+    edition,
+    activeParticipationId,
+    canDelete,
+  } = useSubmitPageData(id);
 
   if (isLoading || isEditionLoading) {
     return (
@@ -93,7 +64,6 @@ export default function SubmitPage({ params }: { params: Promise<{ id: string }>
   }
 
   const isClosed = sharingStatus === 'closed';
-  const canDelete = !!(currentOrg?.role === 'owner' || user?.isAdmin);
 
   return (
     <div className='space-y-6'>
@@ -168,7 +138,7 @@ export default function SubmitPage({ params }: { params: Promise<{ id: string }>
               isClosed={isClosed}
               canDelete={canDelete}
               organizationId={organizationId}
-              onSuccess={invalidateStatus}
+              onSuccess={() => {}}
             />
           ) : (
             <EmptyState
@@ -186,7 +156,7 @@ export default function SubmitPage({ params }: { params: Promise<{ id: string }>
           isClosed={isClosed}
           canDelete={canDelete}
           organizationId={organizationId}
-          onSuccess={invalidateStatus}
+          onSuccess={() => {}}
         />
       ) : (
         <EmptyState title='この大会回への出場登録がありません' />
@@ -194,30 +164,6 @@ export default function SubmitPage({ params }: { params: Promise<{ id: string }>
     </div>
   );
 }
-
-type TemplateItem = {
-  id: string;
-  name: string;
-  description?: string | null;
-  acceptType: 'file' | 'url';
-  isRequired: boolean;
-  allowedExtensions: string[] | null;
-  urlPattern: string | null;
-  maxFileSizeMb: number;
-  sortOrder: number;
-};
-
-type StatusItem = {
-  participationId: string;
-  templateId: string;
-  submission: {
-    id: string;
-    version: number;
-    fileName: string | null;
-    url: string | null;
-    updatedAt?: unknown;
-  } | null;
-};
 
 function TemplateList({
   editionId,
@@ -281,128 +227,17 @@ function TemplateCard({
   organizationId: string;
   onSuccess: () => void;
 }) {
-  const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [urlValue, setUrlValue] = useState(submission?.url ?? '');
-  const invalidateSubmissionQueries = () => {
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.editions.mySubmissionStatus(editionId, organizationId),
-    });
-    queryClient.invalidateQueries({
-      queryKey: ['editions', editionId, 'submission-matrix', organizationId],
-    });
-    queryClient.invalidateQueries({
-      queryKey: ['participations', participationId, 'submissions', organizationId],
-    });
-    if (submission) {
-      queryClient.invalidateQueries({
-        queryKey: ['submissions', submission.id, 'history', organizationId],
-      });
-    }
-  };
-
-  const deleteMutation = useMutation({
-    mutationFn: async () => {
-      if (!submission) return;
-      const result = await apiClient.DELETE('/api/submissions/{id}', {
-        params: { path: { id: submission.id } },
-        headers: { 'X-Organization-Id': organizationId },
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      toast.success('資料を削除しました');
-      invalidateSubmissionQueries();
-      onSuccess();
-    },
-    onError: (err) => {
-      toast.error(getApiErrorMessage(err, 'submission'));
-    },
-  });
-
-  const uploadFileMutation = useMutation({
-    mutationFn: async (file: File) => {
-      const validation = validateFile(file, template);
-      if (!validation.ok) throw new Error(validation.message);
-
-      // 1. Presign
-      const presignResult = await apiClient.POST('/api/upload/presign', {
-        body: {
-          participationId,
-          templateId: template.id,
-          fileName: file.name,
-          contentType: file.type,
-          fileSizeBytes: file.size,
-        },
-        headers: { 'X-Organization-Id': organizationId },
-      });
-      const presign = throwIfError(presignResult);
-
-      // 2. S3 PUT
-      setUploadProgress(0);
-      await s3Put(presign.data.presignedUrl, file, setUploadProgress);
-
-      // 3. Submit
-      const body = {
-        s3Key: presign.data.s3Key,
-        fileName: file.name,
-        fileSizeBytes: file.size,
-        mimeType: file.type,
-      };
-
-      if (submission) {
-        const r = await apiClient.PUT('/api/submissions/{id}', {
-          params: { path: { id: submission.id } },
-          body,
-          headers: { 'X-Organization-Id': organizationId },
-        });
-        throwIfError(r);
-      } else {
-        const r = await apiClient.POST('/api/submissions', {
-          body: { ...body, templateId: template.id, participationId },
-          headers: { 'X-Organization-Id': organizationId },
-        });
-        throwIfError(r);
-      }
-    },
-    onSuccess: () => {
-      setUploadProgress(null);
-      toast.success('資料をアップロードしました');
-      invalidateSubmissionQueries();
-      onSuccess();
-    },
-    onError: (err) => {
-      setUploadProgress(null);
-      toast.error(err instanceof Error ? err.message : getApiErrorMessage(err, 'submission'));
-    },
-  });
-
-  const submitUrlMutation = useMutation({
-    mutationFn: async (url: string) => {
-      if (submission) {
-        const r = await apiClient.PUT('/api/submissions/{id}', {
-          params: { path: { id: submission.id } },
-          body: { url },
-          headers: { 'X-Organization-Id': organizationId },
-        });
-        throwIfError(r);
-      } else {
-        const r = await apiClient.POST('/api/submissions', {
-          body: { url, templateId: template.id, participationId },
-          headers: { 'X-Organization-Id': organizationId },
-        });
-        throwIfError(r);
-      }
-    },
-    onSuccess: () => {
-      toast.success('URLを登録しました');
-      invalidateSubmissionQueries();
-      onSuccess();
-    },
-    onError: (err) => {
-      toast.error(getApiErrorMessage(err, 'submission'));
-    },
+  const { deleteMutation, uploadFileMutation, submitUrlMutation } = useTemplateSubmissionMutations({
+    editionId,
+    participationId,
+    template,
+    submission,
+    organizationId,
+    onSuccess,
+    setUploadProgress,
   });
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -468,7 +303,7 @@ function TemplateCard({
                 rel='noopener noreferrer'
                 className='flex items-center gap-1 text-primary hover:underline text-xs truncate'
               >
-                <ExternalLinkIcon className='h-3 w-3 flex-shrink-0' />
+                <ExternalLinkIcon className='h-3 w-3 shrink-0' />
                 {submission.url}
               </a>
             ) : null}

--- a/apps/frontend/app/(authenticated)/editions/[id]/teams/[participationId]/page.tsx
+++ b/apps/frontend/app/(authenticated)/editions/[id]/teams/[participationId]/page.tsx
@@ -8,18 +8,17 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
-import { useAuth } from '@/contexts/AuthContext';
-import { useOrganization } from '@/contexts/OrganizationContext';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import {
+  downloadSubmission,
+  useTeamCommentMutations,
+  useTeamDetailData,
+} from '@/features/editions/team-detail/hooks';
+import { ApiError } from '@/lib/api/client';
 import type { paths } from '@/lib/api/schema';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { DownloadIcon, ExternalLinkIcon, LockIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { parseAsInteger, useQueryStates } from 'nuqs';
 import { use, useState } from 'react';
-import { toast } from 'sonner';
 
 const paginationParsers = {
   page: parseAsInteger.withDefault(1),
@@ -55,119 +54,35 @@ export default function TeamDetailPage({
   params: Promise<{ id: string; participationId: string }>;
 }) {
   const { participationId } = use(params);
-  const { organizationId } = useOrganization();
-  const { user } = useAuth();
-  const queryClient = useQueryClient();
 
   const [subQueryParams, setSubQueryParams] = useQueryStates(paginationParsers);
   const [commentBody, setCommentBody] = useState('');
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const [editingBody, setEditingBody] = useState('');
 
-  const { data: participation, isLoading: participationLoading } = useQuery({
-    queryKey: queryKeys.participations.detail(participationId, organizationId ?? ''),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/participations/{id}', {
-        params: { path: { id: participationId } },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      return throwIfError(result);
-    },
-  });
-
-  const { data: submissions, isLoading: submissionsLoading } = useQuery({
-    queryKey: queryKeys.participations.submissions(
-      participationId,
-      organizationId ?? '',
-      subQueryParams,
-    ),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/participations/{id}/submissions', {
-        params: {
-          path: { id: participationId },
-          query: { page: subQueryParams.page, pageSize: subQueryParams.pageSize },
-        },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      return throwIfError(result);
-    },
-  });
-
   const {
-    data: comments,
-    isLoading: commentsLoading,
-    error: commentsError,
-  } = useQuery({
-    queryKey: queryKeys.participations.comments(participationId, organizationId ?? '', {}),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/participations/{id}/comments', {
-        params: { path: { id: participationId }, query: { pageSize: 100 } },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      return throwIfError(result);
-    },
-  });
+    organizationId,
+    user,
+    participation,
+    participationLoading,
+    submissions,
+    submissionsLoading,
+    comments,
+    commentsLoading,
+    commentsError,
+  } = useTeamDetailData(participationId, subQueryParams);
 
-  const postCommentMutation = useMutation({
-    mutationFn: async (body: string) => {
-      const result = await apiClient.POST('/api/participations/{id}/comments', {
-        params: { path: { id: participationId } },
-        body: { body },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      setCommentBody('');
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.participations.comments(participationId, organizationId ?? '', {}),
-      });
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const updateCommentMutation = useMutation({
-    mutationFn: async ({ id, body }: { id: string; body: string }) => {
-      const result = await apiClient.PUT('/api/comments/{id}', {
-        params: { path: { id } },
-        body: { body },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      setEditingCommentId(null);
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.participations.comments(participationId, organizationId ?? '', {}),
-      });
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const deleteCommentMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const result = await apiClient.DELETE('/api/comments/{id}', {
-        params: { path: { id } },
-        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.participations.comments(participationId, organizationId ?? '', {}),
-      });
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const handleDownload = async (submissionId: string) => {
-    const result = await apiClient.GET('/api/submissions/{id}/download', {
-      params: { path: { id: submissionId } },
-      headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+  const { postCommentMutation, updateCommentMutation, deleteCommentMutation } =
+    useTeamCommentMutations({
+      participationId,
+      organizationId: organizationId ?? '',
+      onPostSuccess: () => {
+        setCommentBody('');
+      },
+      onUpdateSuccess: () => {
+        setEditingCommentId(null);
+      },
     });
-    const data = throwIfError(result);
-    window.open(data.data.presignedUrl, '_blank');
-  };
 
   const submissionColumns: ColumnDef<ParticipationSubmissionItem>[] = [
     {
@@ -206,7 +121,7 @@ export default function TeamDetailPage({
             <Button
               variant='ghost'
               size='sm'
-              onClick={() => handleDownload(id)}
+              onClick={() => downloadSubmission(id, organizationId ?? '')}
               className='flex items-center gap-1 text-primary cursor-pointer'
             >
               <DownloadIcon className='h-3 w-3 mr-1' />

--- a/apps/frontend/app/(authenticated)/university/settings/page.tsx
+++ b/apps/frontend/app/(authenticated)/university/settings/page.tsx
@@ -13,110 +13,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { useAuth } from '@/contexts/AuthContext';
-import { useOrganization } from '@/contexts/OrganizationContext';
-import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { getApiErrorMessage } from '@/lib/utils/errors';
+import { type Member, useUniversitySettingsPage } from '@/features/university/settings/hooks';
 import { ROLE_LABELS } from '@/lib/utils/status';
-import { useForm } from '@tanstack/react-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
-import { toast } from 'sonner';
-import { z } from 'zod';
-
-type Member = {
-  id: string;
-  userId: string;
-  name: string;
-  email: string;
-  role: 'owner' | 'member';
-  createdAt: unknown;
-};
 
 export default function UniversitySettingsPage() {
-  const { user } = useAuth();
-  const { organizationId, currentOrg } = useOrganization();
-  const queryClient = useQueryClient();
-  const canEdit = currentOrg?.role === 'owner' || user?.isAdmin;
-
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.university.members(organizationId ?? '', {}),
-    queryFn: async () => {
-      if (!organizationId) return null;
-      const result = await apiClient.GET('/api/university/members', {
-        params: { header: { 'x-organization-id': organizationId } },
-      });
-      return throwIfError(result);
-    },
-    enabled: !!organizationId,
-  });
-
-  const inviteForm = useForm({
-    defaultValues: { email: '', role: 'member' as 'owner' | 'member' },
-    onSubmit: async ({ value }) => {
-      await inviteMutation.mutateAsync(value);
-    },
-  });
-
-  const inviteMutation = useMutation({
-    mutationFn: async (values: { email: string; role: 'owner' | 'member' }) => {
-      const result = await apiClient.POST('/api/university/invite', {
-        params: { header: { 'x-organization-id': organizationId ?? '' } },
-        body: { email: values.email, role: values.role },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      toast.success('招待メールを送信しました');
-      inviteForm.reset();
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const changeRoleMutation = useMutation({
-    mutationFn: async ({ memberId, role }: { memberId: string; role: string }) => {
-      const result = await apiClient.PUT('/api/university/members/{id}/role', {
-        params: { path: { id: memberId }, header: { 'x-organization-id': organizationId ?? '' } },
-        body: { role: role as 'owner' | 'member' },
-      });
-      return throwIfError(result);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.university.members(organizationId ?? '', {}),
-      });
-    },
-    onError: (err) => {
-      const msg =
-        err instanceof ApiError && err.status === 409
-          ? '最後のオーナーは変更できません'
-          : getApiErrorMessage(err);
-      toast.error(msg);
-    },
-  });
-
-  const deleteMemberMutation = useMutation({
-    mutationFn: async (memberId: string) => {
-      const result = await apiClient.DELETE('/api/university/members/{id}', {
-        params: { path: { id: memberId }, header: { 'x-organization-id': organizationId ?? '' } },
-      });
-      if (!result.response.ok) throw new ApiError(result.response.status, result.error);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.university.members(organizationId ?? '', {}),
-      });
-      toast.success('メンバーを削除しました');
-    },
-    onError: (err) => {
-      const msg =
-        err instanceof ApiError && err.status === 409
-          ? '最後のオーナーは削除できません'
-          : getApiErrorMessage(err);
-      toast.error(msg);
-    },
-  });
+  const {
+    currentOrg,
+    canEdit,
+    data,
+    isLoading,
+    inviteForm,
+    inviteMutation,
+    changeRoleMutation,
+    deleteMemberMutation,
+    validators,
+  } = useUniversitySettingsPage();
 
   const columns: ColumnDef<Member>[] = [
     { header: '名前', accessorKey: 'name' },
@@ -183,12 +95,7 @@ export default function UniversitySettingsPage() {
               }}
               className='flex gap-3 flex-wrap'
             >
-              <inviteForm.Field
-                name='email'
-                validators={{
-                  onChange: z.string().email('有効なメールアドレスを入力してください'),
-                }}
-              >
+              <inviteForm.Field name='email' validators={{ onChange: validators.email }}>
                 {(field) => (
                   <div className='flex-1 min-w-48 space-y-1'>
                     <Input

--- a/apps/frontend/app/(public)/auth/login/page.tsx
+++ b/apps/frontend/app/(public)/auth/login/page.tsx
@@ -3,38 +3,16 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { useInvalidateMe } from '@/contexts/AuthContext';
-import { authClient } from '@/lib/auth/client';
-import { useForm } from '@tanstack/react-form';
+import { useLoginForm } from '@/features/public/auth/login/hooks';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
-import { z } from 'zod';
 
 export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get('callbackUrl') ?? '/dashboard';
-  const invalidateMe = useInvalidateMe();
-  const [error, setError] = useState<string | null>(null);
-
-  const form = useForm({
-    defaultValues: { email: '', password: '' },
-    onSubmit: async ({ value }) => {
-      setError(null);
-      const result = await authClient.signIn.email({
-        email: value.email,
-        password: value.password,
-      });
-
-      if (result.error) {
-        setError('メールアドレスまたはパスワードが正しくありません');
-        return;
-      }
-
-      await invalidateMe();
-      router.push(callbackUrl);
-    },
+  const { form, error, validators } = useLoginForm(() => {
+    router.push(callbackUrl);
   });
 
   return (
@@ -52,10 +30,7 @@ export default function LoginPage() {
             }}
             className='space-y-4'
           >
-            <form.Field
-              name='email'
-              validators={{ onChange: z.string().email('有効なメールアドレスを入力してください') }}
-            >
+            <form.Field name='email' validators={{ onChange: validators.email }}>
               {(field) => (
                 <div className='space-y-1'>
                   <label htmlFor={field.name} className='text-sm font-medium'>
@@ -75,10 +50,7 @@ export default function LoginPage() {
                 </div>
               )}
             </form.Field>
-            <form.Field
-              name='password'
-              validators={{ onChange: z.string().min(1, 'パスワードを入力してください') }}
-            >
+            <form.Field name='password' validators={{ onChange: validators.password }}>
               {(field) => (
                 <div className='space-y-1'>
                   <label htmlFor={field.name} className='text-sm font-medium'>

--- a/apps/frontend/app/(public)/auth/register/page.tsx
+++ b/apps/frontend/app/(public)/auth/register/page.tsx
@@ -3,37 +3,14 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { useInvalidateMe } from '@/contexts/AuthContext';
-import { authClient } from '@/lib/auth/client';
-import { useForm } from '@tanstack/react-form';
+import { useRegisterForm } from '@/features/public/auth/register/hooks';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { z } from 'zod';
 
 export default function RegisterPage() {
   const router = useRouter();
-  const invalidateMe = useInvalidateMe();
-  const [error, setError] = useState<string | null>(null);
-
-  const form = useForm({
-    defaultValues: { name: '', email: '', password: '', confirmPassword: '' },
-    onSubmit: async ({ value }) => {
-      setError(null);
-      const result = await authClient.signUp.email({
-        name: value.name,
-        email: value.email,
-        password: value.password,
-      });
-
-      if (result.error) {
-        setError(result.error.message ?? 'アカウント作成に失敗しました');
-        return;
-      }
-
-      await invalidateMe();
-      router.push('/dashboard');
-    },
+  const { form, error, validators } = useRegisterForm(() => {
+    router.push('/dashboard');
   });
 
   return (
@@ -51,10 +28,7 @@ export default function RegisterPage() {
             }}
             className='space-y-4'
           >
-            <form.Field
-              name='name'
-              validators={{ onChange: z.string().min(1, '名前を入力してください') }}
-            >
+            <form.Field name='name' validators={{ onChange: validators.name }}>
               {(field) => (
                 <div className='space-y-1'>
                   <label htmlFor={field.name} className='text-sm font-medium'>
@@ -73,10 +47,7 @@ export default function RegisterPage() {
                 </div>
               )}
             </form.Field>
-            <form.Field
-              name='email'
-              validators={{ onChange: z.string().email('有効なメールアドレスを入力してください') }}
-            >
+            <form.Field name='email' validators={{ onChange: validators.email }}>
               {(field) => (
                 <div className='space-y-1'>
                   <label htmlFor={field.name} className='text-sm font-medium'>
@@ -96,12 +67,7 @@ export default function RegisterPage() {
                 </div>
               )}
             </form.Field>
-            <form.Field
-              name='password'
-              validators={{
-                onChange: z.string().min(8, 'パスワードは8文字以上で入力してください'),
-              }}
-            >
+            <form.Field name='password' validators={{ onChange: validators.password }}>
               {(field) => (
                 <div className='space-y-1'>
                   <label htmlFor={field.name} className='text-sm font-medium'>
@@ -125,10 +91,10 @@ export default function RegisterPage() {
               validators={{
                 onChangeListenTo: ['password'],
                 onChange: ({ value, fieldApi }) => {
-                  if (value !== fieldApi.form.getFieldValue('password')) {
-                    return { message: 'パスワードが一致しません' };
-                  }
-                  return undefined;
+                  return validators.confirmPassword({
+                    value,
+                    password: fieldApi.form.getFieldValue('password'),
+                  });
                 },
               }}
             >

--- a/apps/frontend/app/(public)/competitions/[editionId]/page.tsx
+++ b/apps/frontend/app/(public)/competitions/[editionId]/page.tsx
@@ -7,9 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/contexts/AuthContext';
-import { apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { useQuery } from '@tanstack/react-query';
+import { useCompetitionDetail } from '@/features/public/competition-detail/query';
 import Link from 'next/link';
 import { use } from 'react';
 
@@ -18,15 +16,7 @@ export default function EditionDetailPage({ params }: { params: Promise<{ editio
   const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const loginHref = `/auth/login?callbackUrl=${encodeURIComponent(`/competitions/${editionId}`)}`;
 
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.editions.detail(editionId),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/editions/{id}', {
-        params: { path: { id: editionId } },
-      });
-      return throwIfError(result);
-    },
-  });
+  const { data, isLoading } = useCompetitionDetail(editionId);
 
   const edition = data?.data;
 

--- a/apps/frontend/app/(public)/competitions/page.tsx
+++ b/apps/frontend/app/(public)/competitions/page.tsx
@@ -5,9 +5,10 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
-import { apiClient, throwIfError } from '@/lib/api/client';
-import { queryKeys } from '@/lib/query/keys';
-import { useQuery } from '@tanstack/react-query';
+import {
+  useCompetitionsEditions,
+  useCompetitionsSeries,
+} from '@/features/public/competitions/query';
 import { ChevronDownIcon, ChevronRightIcon, ExternalLinkIcon } from 'lucide-react';
 import Link from 'next/link';
 import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
@@ -23,28 +24,8 @@ export default function CompetitionsPage() {
   const [params, setParams] = useQueryStates(paginationParsers);
   const [expandedSeries, setExpandedSeries] = useState<Record<string, boolean>>({});
 
-  const { data, isLoading } = useQuery({
-    queryKey: queryKeys.series.all(params),
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/series', {
-        params: {
-          query: { page: params.page, pageSize: params.pageSize, q: params.q || undefined },
-        },
-      });
-      return throwIfError(result);
-    },
-  });
-
-  // Fetch editions for expanded series
-  const { data: allEditions } = useQuery({
-    queryKey: ['editions-all'],
-    queryFn: async () => {
-      const result = await apiClient.GET('/api/editions', {
-        params: { query: { pageSize: 100 } },
-      });
-      return throwIfError(result);
-    },
-  });
+  const { data, isLoading } = useCompetitionsSeries(params);
+  const { data: allEditions } = useCompetitionsEditions();
 
   const handleSearch = (q: string) => {
     setParams({ q, page: 1 });

--- a/apps/frontend/features/account/settings/hooks.ts
+++ b/apps/frontend/features/account/settings/hooks.ts
@@ -1,0 +1,81 @@
+import { useAuth, useInvalidateMe } from '@/contexts/AuthContext';
+import { authClient } from '@/lib/auth/client';
+import { useForm } from '@tanstack/react-form';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+export function useAccountSettingsForms() {
+  const { user } = useAuth();
+  const invalidateMe = useInvalidateMe();
+
+  const updateProfileMutation = useMutation({
+    mutationFn: async (values: { name: string }) => {
+      const result = await authClient.updateUser({ name: values.name });
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+    },
+    onSuccess: async () => {
+      await invalidateMe();
+      toast.success('プロフィールを更新しました');
+    },
+    onError: (err) => toast.error(err instanceof Error ? err.message : '更新に失敗しました'),
+  });
+
+  const profileForm = useForm({
+    defaultValues: { name: user?.name ?? '' },
+    onSubmit: async ({ value }) => {
+      await updateProfileMutation.mutateAsync(value);
+    },
+  });
+
+  const changePasswordMutation = useMutation({
+    mutationFn: async (values: {
+      currentPassword: string;
+      newPassword: string;
+      confirmPassword: string;
+    }) => {
+      const result = await authClient.changePassword({
+        currentPassword: values.currentPassword,
+        newPassword: values.newPassword,
+      });
+      if (result.error) {
+        throw new Error(result.error.message);
+      }
+    },
+    onSuccess: () => {
+      passwordForm.reset();
+      toast.success('パスワードを変更しました');
+    },
+    onError: (err) =>
+      toast.error(err instanceof Error ? err.message : 'パスワード変更に失敗しました'),
+  });
+
+  const passwordForm = useForm({
+    defaultValues: { currentPassword: '', newPassword: '', confirmPassword: '' },
+    onSubmit: async ({ value }) => {
+      await changePasswordMutation.mutateAsync(value);
+    },
+  });
+
+  return {
+    user,
+    profileForm,
+    passwordForm,
+    updateProfileMutation,
+    changePasswordMutation,
+    validators: {
+      profileName: z.string().min(1, '名前を入力してください'),
+      currentPassword: z.string().min(1, '現在のパスワードを入力してください'),
+      newPassword: z.string().min(8, '新しいパスワードは8文字以上で入力してください'),
+      confirmPassword: ({ value, newPassword }: { value: string; newPassword: string }) => {
+        if (value !== newPassword) {
+          return { message: 'パスワードが一致しません' };
+        }
+
+        return undefined;
+      },
+    },
+  };
+}

--- a/apps/frontend/features/admin/editions/EditionFormDialog.tsx
+++ b/apps/frontend/features/admin/editions/EditionFormDialog.tsx
@@ -1,0 +1,222 @@
+import { Button } from '@/components/ui/button';
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { useForm } from '@tanstack/react-form';
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import { useState } from 'react';
+import { z } from 'zod';
+import { useUpsertEditionMutation } from './mutations';
+import { useSeriesForEditionForm } from './query';
+import type { Edition, ExternalLink, SharingStatus } from './types';
+import { SHARING_STATUS_LABELS } from './types';
+
+type Props = {
+  editing: Edition | null;
+  onClose: () => void;
+};
+
+export function EditionFormDialog({ editing, onClose }: Props) {
+  const [externalLinks, setExternalLinks] = useState<ExternalLink[]>(editing?.externalLinks ?? []);
+  const { data: seriesData } = useSeriesForEditionForm();
+  const mutation = useUpsertEditionMutation(editing, externalLinks, onClose);
+
+  const form = useForm({
+    defaultValues: {
+      seriesId: editing?.seriesId ?? '',
+      year: editing?.year ?? new Date().getFullYear(),
+      name: editing?.name ?? '',
+      description: editing?.description ?? '',
+      sharingStatus: (editing?.sharingStatus ?? 'draft') as SharingStatus,
+    },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync(value);
+    },
+  });
+
+  const series = seriesData?.data ?? [];
+
+  const updateLink = (index: number, field: keyof ExternalLink, value: string) => {
+    setExternalLinks((prev) =>
+      prev.map((link, current) => (current === index ? { ...link, [field]: value } : link)),
+    );
+  };
+
+  const removeLink = (index: number) => {
+    setExternalLinks((prev) => prev.filter((_, current) => current !== index));
+  };
+
+  return (
+    <DialogContent className='max-w-lg max-h-[80vh] overflow-y-auto'>
+      <DialogHeader>
+        <DialogTitle>{editing ? '大会回を編集' : '新規大会回作成'}</DialogTitle>
+      </DialogHeader>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          form.handleSubmit();
+        }}
+        className='space-y-4'
+      >
+        <form.Field
+          name='seriesId'
+          validators={{ onChange: z.string().min(1, 'シリーズを選択してください') }}
+        >
+          {(field) => (
+            <div className='space-y-1'>
+              <span className='text-sm font-medium'>シリーズ *</span>
+              <Select
+                value={field.state.value}
+                onValueChange={(value) => field.handleChange(value ?? '')}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder='選択...'>
+                    {series.find((item) => item.id === field.state.value)?.name}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {series.map((item) => (
+                    <SelectItem key={item.id} value={item.id}>
+                      {item.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {field.state.meta.errors[0] && (
+                <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
+              )}
+            </div>
+          )}
+        </form.Field>
+
+        <div className='flex gap-3'>
+          <form.Field name='year' validators={{ onChange: z.number().int().min(2000) }}>
+            {(field) => (
+              <div className='space-y-1 w-24'>
+                <label htmlFor={field.name} className='text-sm font-medium'>
+                  年度 *
+                </label>
+                <Input
+                  id={field.name}
+                  type='number'
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(Number(event.target.value))}
+                />
+              </div>
+            )}
+          </form.Field>
+          <form.Field
+            name='name'
+            validators={{ onChange: z.string().min(1, '名称を入力してください') }}
+          >
+            {(field) => (
+              <div className='space-y-1 flex-1'>
+                <label htmlFor={field.name} className='text-sm font-medium'>
+                  名称 *
+                </label>
+                <Input
+                  id={field.name}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                />
+                {field.state.meta.errors[0] && (
+                  <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
+                )}
+              </div>
+            )}
+          </form.Field>
+        </div>
+
+        <form.Field name='description'>
+          {(field) => (
+            <div className='space-y-1'>
+              <label htmlFor={field.name} className='text-sm font-medium'>
+                説明
+              </label>
+              <Textarea
+                id={field.name}
+                rows={2}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name='sharingStatus'>
+          {(field) => (
+            <div className='space-y-1'>
+              <span className='text-sm font-medium'>共有状態</span>
+              <Select
+                value={field.state.value}
+                onValueChange={(value) => field.handleChange(value as SharingStatus)}
+              >
+                <SelectTrigger>
+                  <SelectValue>{SHARING_STATUS_LABELS[field.state.value]}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='draft'>準備中</SelectItem>
+                  <SelectItem value='accepting'>受付中</SelectItem>
+                  <SelectItem value='sharing'>共有中</SelectItem>
+                  <SelectItem value='closed'>締切後</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </form.Field>
+
+        <div className='space-y-2'>
+          <p className='text-sm font-medium'>外部リンク</p>
+          {externalLinks.map((link, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: dynamic list
+            <div key={index} className='flex gap-2'>
+              <Input
+                placeholder='ラベル'
+                value={link.label}
+                onChange={(event) => updateLink(index, 'label', event.target.value)}
+                className='w-24'
+              />
+              <Input
+                placeholder='URL'
+                value={link.url}
+                onChange={(event) => updateLink(index, 'url', event.target.value)}
+                className='flex-1'
+              />
+              <Button type='button' variant='ghost' size='sm' onClick={() => removeLink(index)}>
+                <Trash2Icon className='h-3 w-3' />
+              </Button>
+            </div>
+          ))}
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={() => setExternalLinks((prev) => [...prev, { label: '', url: '' }])}
+          >
+            <PlusIcon className='h-3 w-3 mr-1' />
+            追加
+          </Button>
+        </div>
+
+        <div className='flex justify-end gap-2'>
+          <Button type='button' variant='ghost' onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button type='submit' disabled={mutation.isPending}>
+            {editing ? '更新' : '作成'}
+          </Button>
+        </div>
+      </form>
+    </DialogContent>
+  );
+}

--- a/apps/frontend/features/admin/editions/mutations.ts
+++ b/apps/frontend/features/admin/editions/mutations.ts
@@ -1,0 +1,131 @@
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateAdminEditionsQueries } from '@/lib/query/invalidation';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { s3Put } from '@/lib/utils/file';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { Edition, EditionFormValues, ExternalLink, SharingStatus } from './types';
+
+type UploadEditionRuleVariables = {
+  editionId: string;
+  file: File;
+  existingDocuments: { label: string; s3_key: string; mime_type: string }[];
+};
+
+export function useUpsertEditionMutation(
+  editing: Edition | null,
+  externalLinks: ExternalLink[],
+  onClose: () => void,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (values: EditionFormValues) => {
+      const body = {
+        seriesId: values.seriesId,
+        year: values.year,
+        name: values.name,
+        description: values.description,
+        sharingStatus: values.sharingStatus,
+        externalLinks: externalLinks.length ? externalLinks : undefined,
+      };
+      if (editing) {
+        const result = await apiClient.PUT('/api/admin/editions/{id}', {
+          params: { path: { id: editing.id } },
+          body,
+        });
+        return throwIfError(result);
+      }
+      const result = await apiClient.POST('/api/admin/editions', { body });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminEditionsQueries(queryClient);
+      toast.success(editing ? '更新しました' : '作成しました');
+      onClose();
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}
+
+export function useDeleteEditionMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const result = await apiClient.DELETE('/api/admin/editions/{id}', {
+        params: { path: { id } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      await invalidateAdminEditionsQueries(queryClient);
+      toast.success('削除しました');
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}
+
+export function useChangeEditionStatusMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, status }: { id: string; status: SharingStatus }) => {
+      const result = await apiClient.PUT('/api/admin/editions/{id}/status', {
+        params: { path: { id } },
+        body: { sharingStatus: status },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminEditionsQueries(queryClient);
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}
+
+export function useUploadEditionRuleMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (variables: UploadEditionRuleVariables) => {
+      const presignResult = await apiClient.POST('/api/admin/editions/{id}/rules/presign', {
+        params: { path: { id: variables.editionId } },
+        body: { fileName: variables.file.name, contentType: variables.file.type },
+      });
+      const presign = throwIfError(presignResult);
+
+      await s3Put(presign.data.presignedUrl, variables.file);
+
+      const updateResult = await apiClient.PUT('/api/admin/editions/{id}/rules', {
+        params: { path: { id: variables.editionId } },
+        body: {
+          ruleDocuments: [
+            ...variables.existingDocuments,
+            {
+              label: variables.file.name,
+              s3_key: presign.data.s3Key,
+              mime_type: variables.file.type,
+            },
+          ],
+        },
+      });
+      return throwIfError(updateResult);
+    },
+    onSuccess: async () => {
+      await invalidateAdminEditionsQueries(queryClient);
+      toast.success('ルール資料をアップロードしました');
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}

--- a/apps/frontend/features/admin/editions/query.ts
+++ b/apps/frontend/features/admin/editions/query.ts
@@ -1,0 +1,34 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { useQuery } from '@tanstack/react-query';
+import type { AdminEditionsQueryParams } from './types';
+
+export function useAdminEditionsList(queryParams: AdminEditionsQueryParams) {
+  return useQuery({
+    queryKey: queryKeys.admin.editions(queryParams),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions', {
+        params: {
+          query: {
+            page: queryParams.page,
+            pageSize: queryParams.pageSize,
+            q: queryParams.q || undefined,
+          },
+        },
+      });
+      return throwIfError(result);
+    },
+  });
+}
+
+export function useSeriesForEditionForm() {
+  return useQuery({
+    queryKey: queryKeys.series.allForSelection(),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/series', {
+        params: { query: { pageSize: 100 } },
+      });
+      return throwIfError(result);
+    },
+  });
+}

--- a/apps/frontend/features/admin/editions/types.ts
+++ b/apps/frontend/features/admin/editions/types.ts
@@ -1,0 +1,44 @@
+export type SharingStatus = 'draft' | 'accepting' | 'sharing' | 'closed';
+
+export const SHARING_STATUS_LABELS: Record<SharingStatus, string> = {
+  draft: '準備中',
+  accepting: '受付中',
+  sharing: '共有中',
+  closed: '締切後',
+};
+
+export type EditionRuleDocument = {
+  label: string;
+  s3_key: string;
+  mime_type: string;
+  url: string;
+};
+
+export type Edition = {
+  id: string;
+  seriesId: string;
+  year: number;
+  name: string;
+  description: string | null;
+  ruleDocuments: EditionRuleDocument[] | null;
+  sharingStatus: SharingStatus;
+  externalLinks: { label: string; url: string }[] | null;
+  createdAt: unknown;
+  updatedAt: unknown;
+};
+
+export type ExternalLink = { label: string; url: string };
+
+export type AdminEditionsQueryParams = {
+  page: number;
+  pageSize: number;
+  q: string;
+};
+
+export type EditionFormValues = {
+  seriesId: string;
+  year: number;
+  name: string;
+  description: string;
+  sharingStatus: SharingStatus;
+};

--- a/apps/frontend/features/admin/participations/hooks.ts
+++ b/apps/frontend/features/admin/participations/hooks.ts
@@ -1,0 +1,99 @@
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateAdminParticipationsQueries } from '@/lib/query/invalidation';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+export type Participation = {
+  id: string;
+  editionId: string;
+  universityId: string;
+  universityName: string;
+  teamName: string | null;
+  createdAt: unknown;
+};
+
+export function useAdminParticipationsPage(editionId: string) {
+  const queryClient = useQueryClient();
+  const [selectedUniversityId, setSelectedUniversityId] = useState('');
+  const [teamName, setTeamName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingTeamName, setEditingTeamName] = useState('');
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.admin.participations(editionId, {}),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/admin/editions/{id}/participations', {
+        params: { path: { id: editionId } },
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const result = await apiClient.POST('/api/admin/editions/{id}/participations', {
+        params: { path: { id: editionId } },
+        body: { universityId: selectedUniversityId, teamName: teamName || undefined },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminParticipationsQueries(queryClient, editionId);
+      setSelectedUniversityId('');
+      setTeamName('');
+      toast.success('出場登録しました');
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({ id, teamName }: { id: string; teamName: string | null }) => {
+      const result = await apiClient.PUT('/api/admin/participations/{id}', {
+        params: { path: { id } },
+        body: { teamName: teamName || null },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminParticipationsQueries(queryClient, editionId);
+      setEditingId(null);
+      toast.success('更新しました');
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const result = await apiClient.DELETE('/api/admin/participations/{id}', {
+        params: { path: { id } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      await invalidateAdminParticipationsQueries(queryClient, editionId);
+      toast.success('削除しました');
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  return {
+    selectedUniversityId,
+    setSelectedUniversityId,
+    teamName,
+    setTeamName,
+    editingId,
+    setEditingId,
+    editingTeamName,
+    setEditingTeamName,
+    data,
+    isLoading,
+    createMutation,
+    updateMutation,
+    deleteMutation,
+  };
+}

--- a/apps/frontend/features/admin/series/SeriesFormDialog.tsx
+++ b/apps/frontend/features/admin/series/SeriesFormDialog.tsx
@@ -1,0 +1,135 @@
+import { Button } from '@/components/ui/button';
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useForm } from '@tanstack/react-form';
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import { useState } from 'react';
+import { z } from 'zod';
+import { useUpsertSeriesMutation } from './mutations';
+import type { ExternalLink, Series } from './types';
+
+type Props = {
+  editing: Series | null;
+  onClose: () => void;
+};
+
+export function SeriesFormDialog({ editing, onClose }: Props) {
+  const [externalLinks, setExternalLinks] = useState<ExternalLink[]>(editing?.externalLinks ?? []);
+  const mutation = useUpsertSeriesMutation(editing, externalLinks, onClose);
+
+  const form = useForm({
+    defaultValues: {
+      name: editing?.name ?? '',
+      description: editing?.description ?? '',
+    },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync(value);
+    },
+  });
+
+  const updateLink = (index: number, field: keyof ExternalLink, value: string) => {
+    setExternalLinks((prev) =>
+      prev.map((link, current) => (current === index ? { ...link, [field]: value } : link)),
+    );
+  };
+
+  const removeLink = (index: number) => {
+    setExternalLinks((prev) => prev.filter((_, current) => current !== index));
+  };
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{editing ? 'シリーズを編集' : '新規シリーズ作成'}</DialogTitle>
+      </DialogHeader>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          form.handleSubmit();
+        }}
+        className='space-y-4'
+      >
+        <form.Field
+          name='name'
+          validators={{ onChange: z.string().min(1, '名称を入力してください') }}
+        >
+          {(field) => (
+            <div className='space-y-1'>
+              <label htmlFor={field.name} className='text-sm font-medium'>
+                名称 *
+              </label>
+              <Input
+                id={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+              {field.state.meta.errors[0] && (
+                <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
+              )}
+            </div>
+          )}
+        </form.Field>
+        <form.Field name='description'>
+          {(field) => (
+            <div className='space-y-1'>
+              <label htmlFor={field.name} className='text-sm font-medium'>
+                説明
+              </label>
+              <Textarea
+                id={field.name}
+                rows={2}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+            </div>
+          )}
+        </form.Field>
+
+        <div className='space-y-2'>
+          <p className='text-sm font-medium'>外部リンク</p>
+          {externalLinks.map((link, index) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: dynamic list
+            <div key={index} className='flex gap-2'>
+              <Input
+                placeholder='ラベル'
+                value={link.label}
+                onChange={(event) => updateLink(index, 'label', event.target.value)}
+                className='w-24'
+              />
+              <Input
+                placeholder='URL'
+                value={link.url}
+                onChange={(event) => updateLink(index, 'url', event.target.value)}
+                className='flex-1'
+              />
+              <Button type='button' variant='ghost' size='sm' onClick={() => removeLink(index)}>
+                <Trash2Icon className='h-3 w-3' />
+              </Button>
+            </div>
+          ))}
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={() => setExternalLinks((prev) => [...prev, { label: '', url: '' }])}
+          >
+            <PlusIcon className='h-3 w-3 mr-1' />
+            リンクを追加
+          </Button>
+        </div>
+
+        <div className='flex justify-end gap-2'>
+          <Button type='button' variant='ghost' onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button type='submit' disabled={mutation.isPending}>
+            {editing ? '更新' : '作成'}
+          </Button>
+        </div>
+      </form>
+    </DialogContent>
+  );
+}

--- a/apps/frontend/features/admin/series/mutations.ts
+++ b/apps/frontend/features/admin/series/mutations.ts
@@ -1,0 +1,63 @@
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateAdminSeriesQueries } from '@/lib/query/invalidation';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { ExternalLink, Series, SeriesFormValues } from './types';
+
+export function useUpsertSeriesMutation(
+  editing: Series | null,
+  externalLinks: ExternalLink[],
+  onClose: () => void,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (values: SeriesFormValues) => {
+      const body = {
+        name: values.name,
+        description: values.description,
+        externalLinks: externalLinks.length ? externalLinks : undefined,
+      };
+      if (editing) {
+        const result = await apiClient.PUT('/api/admin/series/{id}', {
+          params: { path: { id: editing.id } },
+          body,
+        });
+        return throwIfError(result);
+      }
+      const result = await apiClient.POST('/api/admin/series', { body });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminSeriesQueries(queryClient);
+      toast.success(editing ? '更新しました' : '作成しました');
+      onClose();
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}
+
+export function useDeleteSeriesMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const result = await apiClient.DELETE('/api/admin/series/{id}', {
+        params: { path: { id } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      await invalidateAdminSeriesQueries(queryClient);
+      toast.success('削除しました');
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}

--- a/apps/frontend/features/admin/series/query.ts
+++ b/apps/frontend/features/admin/series/query.ts
@@ -1,0 +1,22 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { useQuery } from '@tanstack/react-query';
+import type { AdminSeriesQueryParams } from './types';
+
+export function useAdminSeriesList(queryParams: AdminSeriesQueryParams) {
+  return useQuery({
+    queryKey: queryKeys.admin.series(queryParams),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/series', {
+        params: {
+          query: {
+            page: queryParams.page,
+            pageSize: queryParams.pageSize,
+            q: queryParams.q || undefined,
+          },
+        },
+      });
+      return throwIfError(result);
+    },
+  });
+}

--- a/apps/frontend/features/admin/series/types.ts
+++ b/apps/frontend/features/admin/series/types.ts
@@ -1,0 +1,21 @@
+export type Series = {
+  id: string;
+  name: string;
+  description: string | null;
+  externalLinks: { label: string; url: string }[] | null;
+  createdAt: unknown;
+  updatedAt: unknown;
+};
+
+export type ExternalLink = { label: string; url: string };
+
+export type AdminSeriesQueryParams = {
+  page: number;
+  pageSize: number;
+  q: string;
+};
+
+export type SeriesFormValues = {
+  name: string;
+  description: string;
+};

--- a/apps/frontend/features/admin/templates/TemplateFormDialog.tsx
+++ b/apps/frontend/features/admin/templates/TemplateFormDialog.tsx
@@ -1,0 +1,226 @@
+import { Button } from '@/components/ui/button';
+import { DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { useForm } from '@tanstack/react-form';
+import { z } from 'zod';
+import { useUpsertTemplateMutation } from './mutations';
+import type { Template, TemplateAcceptType } from './types';
+
+const ACCEPT_TYPE_LABELS: Record<TemplateAcceptType, string> = {
+  file: 'ファイル',
+  url: 'URL',
+};
+
+type Props = {
+  editionId: string;
+  editing: Template | null;
+  onClose: () => void;
+};
+
+export function TemplateFormDialog({ editionId, editing, onClose }: Props) {
+  const mutation = useUpsertTemplateMutation(editionId, editing, onClose);
+
+  const form = useForm({
+    defaultValues: {
+      name: editing?.name ?? '',
+      description: editing?.description ?? '',
+      acceptType: (editing?.acceptType ?? 'file') as TemplateAcceptType,
+      allowedExtensions: editing?.allowedExtensions?.join(', ') ?? '',
+      urlPattern: editing?.urlPattern ?? '',
+      maxFileSizeMb: editing?.maxFileSizeMb ?? 100,
+      isRequired: editing?.isRequired ?? false,
+      sortOrder: editing?.sortOrder ?? 0,
+    },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync(value);
+    },
+  });
+
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{editing ? 'テンプレートを編集' : '新規テンプレート作成'}</DialogTitle>
+      </DialogHeader>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          form.handleSubmit();
+        }}
+        className='space-y-4'
+      >
+        <form.Field
+          name='name'
+          validators={{ onChange: z.string().min(1, '名称を入力してください') }}
+        >
+          {(field) => (
+            <div className='space-y-1'>
+              <label htmlFor={field.name} className='text-sm font-medium'>
+                名称 *
+              </label>
+              <Input
+                id={field.name}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+              {field.state.meta.errors[0] && (
+                <p className='text-sm text-destructive'>{field.state.meta.errors[0].message}</p>
+              )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name='description'>
+          {(field) => (
+            <div className='space-y-1'>
+              <label htmlFor={field.name} className='text-sm font-medium'>
+                説明
+              </label>
+              <Textarea
+                id={field.name}
+                rows={2}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name='acceptType'>
+          {(field) => (
+            <div className='space-y-1'>
+              <span className='text-sm font-medium'>種別</span>
+              <Select
+                value={field.state.value}
+                onValueChange={(value) =>
+                  field.handleChange((value ?? 'file') as TemplateAcceptType)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue>{ACCEPT_TYPE_LABELS[field.state.value]}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value='file'>ファイル</SelectItem>
+                  <SelectItem value='url'>URL</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+        </form.Field>
+
+        <form.Subscribe selector={(state) => state.values.acceptType}>
+          {(acceptType) => (
+            <>
+              {acceptType === 'file' && (
+                <>
+                  <form.Field name='allowedExtensions'>
+                    {(field) => (
+                      <div className='space-y-1'>
+                        <label htmlFor={field.name} className='text-sm font-medium'>
+                          許可拡張子（カンマ区切り）
+                        </label>
+                        <Input
+                          id={field.name}
+                          placeholder='pdf, docx'
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => field.handleChange(event.target.value)}
+                        />
+                      </div>
+                    )}
+                  </form.Field>
+
+                  <form.Field name='maxFileSizeMb'>
+                    {(field) => (
+                      <div className='space-y-1'>
+                        <label htmlFor={field.name} className='text-sm font-medium'>
+                          最大ファイルサイズ (MB)
+                        </label>
+                        <Input
+                          id={field.name}
+                          type='number'
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => field.handleChange(Number(event.target.value))}
+                        />
+                      </div>
+                    )}
+                  </form.Field>
+                </>
+              )}
+
+              {acceptType === 'url' && (
+                <form.Field name='urlPattern'>
+                  {(field) => (
+                    <div className='space-y-1'>
+                      <label htmlFor={field.name} className='text-sm font-medium'>
+                        URLパターン（ヒント用）
+                      </label>
+                      <Input
+                        id={field.name}
+                        placeholder='github.com'
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => field.handleChange(event.target.value)}
+                      />
+                    </div>
+                  )}
+                </form.Field>
+              )}
+            </>
+          )}
+        </form.Subscribe>
+
+        <div className='flex gap-4'>
+          <form.Field name='isRequired'>
+            {(field) => (
+              <div className='flex items-center gap-2'>
+                <Switch
+                  checked={field.state.value}
+                  onCheckedChange={(checked) => field.handleChange(checked)}
+                />
+                <span className='text-sm font-medium'>必須</span>
+              </div>
+            )}
+          </form.Field>
+          <form.Field name='sortOrder'>
+            {(field) => (
+              <div className='flex items-center gap-2'>
+                <label htmlFor={field.name} className='text-sm font-medium'>
+                  順序
+                </label>
+                <Input
+                  id={field.name}
+                  type='number'
+                  className='w-16 h-8'
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(Number(event.target.value))}
+                />
+              </div>
+            )}
+          </form.Field>
+        </div>
+
+        <div className='flex justify-end gap-2'>
+          <Button type='button' variant='ghost' onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button type='submit' disabled={mutation.isPending}>
+            {editing ? '更新' : '作成'}
+          </Button>
+        </div>
+      </form>
+    </DialogContent>
+  );
+}

--- a/apps/frontend/features/admin/templates/mutations.ts
+++ b/apps/frontend/features/admin/templates/mutations.ts
@@ -1,0 +1,103 @@
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateAdminTemplatesQueries } from '@/lib/query/invalidation';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { Template, TemplateFormValues } from './types';
+
+export function useUpsertTemplateMutation(
+  editionId: string,
+  editing: Template | null,
+  onClose: () => void,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (values: TemplateFormValues) => {
+      const body = {
+        name: values.name,
+        description: values.description,
+        acceptType: values.acceptType,
+        allowedExtensions:
+          values.acceptType === 'file' && values.allowedExtensions
+            ? values.allowedExtensions
+                .split(',')
+                .map((extension) => extension.trim())
+                .filter(Boolean)
+            : undefined,
+        urlPattern: values.acceptType === 'url' ? values.urlPattern : undefined,
+        maxFileSizeMb: values.maxFileSizeMb,
+        isRequired: values.isRequired,
+        sortOrder: values.sortOrder,
+      };
+
+      if (editing) {
+        const result = await apiClient.PUT('/api/admin/templates/{id}', {
+          params: { path: { id: editing.id } },
+          body,
+        });
+        return throwIfError(result);
+      }
+
+      const result = await apiClient.POST('/api/admin/editions/{id}/templates', {
+        params: { path: { id: editionId } },
+        body,
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminTemplatesQueries(queryClient, editionId);
+      toast.success(editing ? '更新しました' : '作成しました');
+      onClose();
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}
+
+export function useDeleteTemplateMutation(editionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const result = await apiClient.DELETE('/api/admin/templates/{id}', {
+        params: { path: { id } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      await invalidateAdminTemplatesQueries(queryClient, editionId);
+      toast.success('削除しました');
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}
+
+export function useCopyTemplatesMutation(editionId: string, onSuccessCopy: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (sourceEditionId: string) => {
+      const result = await apiClient.POST(
+        '/api/admin/editions/{id}/templates/copy-from/{sourceEditionId}',
+        {
+          params: { path: { id: editionId, sourceEditionId } },
+        },
+      );
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminTemplatesQueries(queryClient, editionId);
+      toast.success('テンプレートをコピーしました');
+      onSuccessCopy();
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error));
+    },
+  });
+}

--- a/apps/frontend/features/admin/templates/query.ts
+++ b/apps/frontend/features/admin/templates/query.ts
@@ -1,0 +1,27 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { useQuery } from '@tanstack/react-query';
+
+export function useAdminTemplates(editionId: string) {
+  return useQuery({
+    queryKey: queryKeys.admin.templates(editionId, { pageSize: 100 }),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions/{id}/templates', {
+        params: { path: { id: editionId }, query: { pageSize: 100 } },
+      });
+      return throwIfError(result);
+    },
+  });
+}
+
+export function useEditionsForTemplateCopy() {
+  return useQuery({
+    queryKey: queryKeys.editions.allForSelection(),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions', {
+        params: { query: { pageSize: 100 } },
+      });
+      return throwIfError(result);
+    },
+  });
+}

--- a/apps/frontend/features/admin/templates/types.ts
+++ b/apps/frontend/features/admin/templates/types.ts
@@ -1,0 +1,25 @@
+export type TemplateAcceptType = 'file' | 'url';
+
+export type Template = {
+  id: string;
+  name: string;
+  description: string | null;
+  acceptType: TemplateAcceptType;
+  allowedExtensions: string[] | null;
+  urlPattern: string | null;
+  maxFileSizeMb: number;
+  isRequired: boolean;
+  sortOrder: number;
+  createdAt: unknown;
+};
+
+export type TemplateFormValues = {
+  name: string;
+  description: string;
+  acceptType: TemplateAcceptType;
+  allowedExtensions: string;
+  urlPattern: string;
+  maxFileSizeMb: number;
+  isRequired: boolean;
+  sortOrder: number;
+};

--- a/apps/frontend/features/admin/universities/hooks.ts
+++ b/apps/frontend/features/admin/universities/hooks.ts
@@ -1,0 +1,70 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateAdminUniversitiesQueries } from '@/lib/query/invalidation';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useForm } from '@tanstack/react-form';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+export type University = {
+  id: string;
+  name: string;
+  slug: string;
+  createdAt: unknown;
+};
+
+export function useAdminUniversitiesList() {
+  return useQuery({
+    queryKey: queryKeys.admin.universities({}),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/admin/universities', {
+        params: { query: { pageSize: 100 } },
+      });
+      return throwIfError(result);
+    },
+  });
+}
+
+export function useCreateUniversityForm(onClose: () => void) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (values: { name: string; slug: string; ownerEmail: string }) => {
+      const result = await apiClient.POST('/api/admin/universities', {
+        body: {
+          name: values.name,
+          slug: values.slug,
+          ownerEmail: values.ownerEmail || undefined,
+        },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      await invalidateAdminUniversitiesQueries(queryClient);
+      toast.success('大学を作成しました');
+      onClose();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const form = useForm({
+    defaultValues: { name: '', slug: '', ownerEmail: '' },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync(value);
+    },
+  });
+
+  return {
+    form,
+    mutation,
+    validators: {
+      name: z.string().min(1, '名称を入力してください'),
+      slug: z
+        .string()
+        .min(1, 'スラッグを入力してください')
+        .regex(/^[a-z0-9-]+$/, '半角英数字とハイフンのみ使用できます'),
+      ownerEmail: z.string().email('有効なメールアドレスを入力してください').or(z.literal('')),
+    },
+  };
+}

--- a/apps/frontend/features/admin/users/hooks.ts
+++ b/apps/frontend/features/admin/users/hooks.ts
@@ -1,0 +1,210 @@
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateAdminUsersQueries } from '@/lib/query/invalidation';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+export type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  isAdmin: boolean;
+  createdAt: unknown;
+  organizationCount: number;
+};
+
+export type Membership = {
+  memberId: string;
+  organizationId: string;
+  organizationName: string;
+  organizationSlug: string;
+  role: 'owner' | 'member';
+  createdAt: unknown;
+};
+
+export const listParsers = {
+  page: parseAsInteger.withDefault(1),
+  pageSize: parseAsInteger.withDefault(20),
+  q: parseAsString.withDefault(''),
+  sort: parseAsString.withDefault('createdAt:desc'),
+};
+
+export function useAdminUsersPageState() {
+  const [queryParams, setQueryParams] = useQueryStates(listParsers);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.admin.users(queryParams),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/admin/users', {
+        params: {
+          query: {
+            page: queryParams.page,
+            pageSize: queryParams.pageSize,
+            q: queryParams.q || undefined,
+            sort: queryParams.sort as
+              | 'name:asc'
+              | 'name:desc'
+              | 'email:asc'
+              | 'email:desc'
+              | 'createdAt:asc'
+              | 'createdAt:desc',
+          },
+        },
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const sortOptions = useMemo(
+    () => [
+      { value: 'createdAt:desc', label: '作成日 新しい順' },
+      { value: 'createdAt:asc', label: '作成日 古い順' },
+      { value: 'name:asc', label: '名前 昇順' },
+      { value: 'name:desc', label: '名前 降順' },
+      { value: 'email:asc', label: 'メール 昇順' },
+      { value: 'email:desc', label: 'メール 降順' },
+    ],
+    [],
+  );
+
+  return {
+    queryParams,
+    setQueryParams,
+    dialogOpen,
+    setDialogOpen,
+    selectedUser,
+    setSelectedUser,
+    data,
+    isLoading,
+    sortOptions,
+  };
+}
+
+export function useMembershipDialog(user: AdminUser | null, open: boolean) {
+  const queryClient = useQueryClient();
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState('');
+  const [selectedRole, setSelectedRole] = useState<'owner' | 'member'>('member');
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedOrganizationId('');
+      setSelectedRole('member');
+    }
+  }, [open]);
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.admin.userMemberships(user?.id ?? ''),
+    queryFn: async () => {
+      if (!user) {
+        return null;
+      }
+      const result = await apiClient.GET('/api/admin/users/{userId}/memberships', {
+        params: { path: { userId: user.id } },
+      });
+      return throwIfError(result);
+    },
+    enabled: open && !!user,
+  });
+
+  const invalidateTargets = async () => {
+    if (!user) {
+      return;
+    }
+
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.userMemberships(user.id) }),
+      invalidateAdminUsersQueries(queryClient),
+      queryClient.invalidateQueries({ queryKey: queryKeys.university.membersPrefix() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.me }),
+    ]);
+  };
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      if (!user || !selectedOrganizationId) {
+        return;
+      }
+      const result = await apiClient.POST('/api/admin/users/{userId}/memberships', {
+        params: { path: { userId: user.id } },
+        body: {
+          organizationId: selectedOrganizationId,
+          role: selectedRole,
+        },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      toast.success('所属を追加しました');
+      setSelectedOrganizationId('');
+      setSelectedRole('member');
+      await invalidateTargets();
+    },
+    onError: (error) => {
+      const message =
+        error instanceof ApiError && error.status === 409
+          ? getApiErrorMessage(error, 'duplicate')
+          : getApiErrorMessage(error);
+      toast.error(message);
+    },
+  });
+
+  const changeRoleMutation = useMutation({
+    mutationFn: async ({ memberId, role }: { memberId: string; role: 'owner' | 'member' }) => {
+      const result = await apiClient.PUT('/api/admin/memberships/{memberId}/role', {
+        params: { path: { memberId } },
+        body: { role },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      toast.success('ロールを更新しました');
+      await invalidateTargets();
+    },
+    onError: (error) => {
+      const message =
+        error instanceof ApiError && error.status === 409
+          ? getApiErrorMessage(error, 'last-owner')
+          : getApiErrorMessage(error);
+      toast.error(message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (memberId: string) => {
+      const result = await apiClient.DELETE('/api/admin/memberships/{memberId}', {
+        params: { path: { memberId } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      toast.success('所属を解除しました');
+      await invalidateTargets();
+    },
+    onError: (error) => {
+      const message =
+        error instanceof ApiError && error.status === 409
+          ? getApiErrorMessage(error, 'last-owner')
+          : getApiErrorMessage(error);
+      toast.error(message);
+    },
+  });
+
+  return {
+    memberships: (data?.data ?? []) as Membership[],
+    isLoading,
+    selectedOrganizationId,
+    setSelectedOrganizationId,
+    selectedRole,
+    setSelectedRole,
+    createMutation,
+    changeRoleMutation,
+    deleteMutation,
+  };
+}

--- a/apps/frontend/features/dashboard/query.ts
+++ b/apps/frontend/features/dashboard/query.ts
@@ -1,0 +1,56 @@
+import { useOrganization } from '@/contexts/OrganizationContext';
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { useQueries, useQuery } from '@tanstack/react-query';
+
+export function useDashboardData() {
+  const { organizationId, currentOrg } = useOrganization();
+
+  const { data: editionsData, isLoading: editionsLoading } = useQuery({
+    queryKey: queryKeys.editions.all({ pageSize: 50 }),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions', {
+        params: { query: { pageSize: 50 } },
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const editions = editionsData?.data ?? [];
+
+  const statusQueries = useQueries({
+    queries: editions.map((edition) => ({
+      queryKey: queryKeys.editions.mySubmissionStatus(edition.id, organizationId ?? ''),
+      queryFn: async () => {
+        if (!organizationId) {
+          return null;
+        }
+
+        const result = await apiClient.GET('/api/editions/{id}/my-submission-status', {
+          params: { path: { id: edition.id } },
+          headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+        });
+
+        if (result.response.status === 403 || result.response.status === 404) {
+          return null;
+        }
+
+        return throwIfError(result);
+      },
+      enabled: !!organizationId,
+    })),
+  });
+
+  const myEditions = editions
+    .map((edition, index) => ({ edition, status: statusQueries[index]?.data }))
+    .filter(({ status }) => status && (status.data?.participations?.length ?? 0) > 0);
+
+  const isLoading = editionsLoading || statusQueries.some((query) => query.isLoading);
+
+  return {
+    organizationId,
+    currentOrg,
+    myEditions,
+    isLoading,
+  };
+}

--- a/apps/frontend/features/editions/submission-history/hooks.ts
+++ b/apps/frontend/features/editions/submission-history/hooks.ts
@@ -1,0 +1,29 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import type { paths } from '@/lib/api/schema';
+import { queryKeys } from '@/lib/query/keys';
+import { useQuery } from '@tanstack/react-query';
+
+type SubmissionHistoryPath = paths['/api/submissions/{id}/history'];
+export type SubmissionHistoryResponse =
+  SubmissionHistoryPath['get']['responses'][200]['content']['application/json'];
+export type SubmissionHistoryRow = SubmissionHistoryResponse['data'][number];
+
+export function useSubmissionHistory(
+  submissionId: string,
+  organizationId: string | null,
+  queryParams: { page: number; pageSize: number },
+) {
+  return useQuery<SubmissionHistoryResponse>({
+    queryKey: queryKeys.submissions.history(submissionId, organizationId ?? '', queryParams),
+    queryFn: async (): Promise<SubmissionHistoryResponse> => {
+      const result = await apiClient.GET('/api/submissions/{id}/history', {
+        params: {
+          path: { id: submissionId },
+          query: { page: queryParams.page, pageSize: queryParams.pageSize },
+        },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      return throwIfError(result);
+    },
+  });
+}

--- a/apps/frontend/features/editions/submit/hooks.ts
+++ b/apps/frontend/features/editions/submit/hooks.ts
@@ -1,0 +1,244 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { useOrganization } from '@/contexts/OrganizationContext';
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateSubmissionStatusQueries } from '@/lib/query/invalidation';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { s3Put, validateFile } from '@/lib/utils/file';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+export type TemplateItem = {
+  id: string;
+  name: string;
+  description?: string | null;
+  acceptType: 'file' | 'url';
+  isRequired: boolean;
+  allowedExtensions: string[] | null;
+  urlPattern: string | null;
+  maxFileSizeMb: number;
+  sortOrder: number;
+};
+
+export type StatusItem = {
+  participationId: string;
+  templateId: string;
+  submission: {
+    id: string;
+    version: number;
+    fileName: string | null;
+    url: string | null;
+    updatedAt?: unknown;
+  } | null;
+};
+
+export function useSubmitPageData(id: string) {
+  const { user } = useAuth();
+  const { organizationId, currentOrg } = useOrganization();
+  const [selectedParticipationId, setSelectedParticipationId] = useState<string | null>(null);
+
+  const { data: editionData, isLoading: isEditionLoading } = useQuery({
+    queryKey: queryKeys.editions.detail(id),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions/{id}', {
+        params: { path: { id } },
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.editions.mySubmissionStatus(id, organizationId ?? ''),
+    queryFn: async () => {
+      if (!organizationId) {
+        return null;
+      }
+      const result = await apiClient.GET('/api/editions/{id}/my-submission-status', {
+        params: { path: { id } },
+        headers: { 'X-Organization-Id': organizationId },
+      });
+      return throwIfError(result);
+    },
+    enabled: !!organizationId,
+  });
+
+  const statusData = data?.data;
+  const participations = statusData?.participations ?? [];
+  const templates = statusData?.templates ?? [];
+  const items = statusData?.items ?? [];
+  const sharingStatus = statusData?.edition?.sharingStatus;
+  const edition = editionData?.data;
+
+  const activeParticipationId =
+    participations.length === 1 ? (participations[0]?.id ?? null) : selectedParticipationId;
+
+  const canDelete = !!(currentOrg?.role === 'owner' || user?.isAdmin);
+
+  return {
+    user,
+    organizationId,
+    selectedParticipationId,
+    setSelectedParticipationId,
+    isEditionLoading,
+    isLoading,
+    statusData,
+    participations,
+    templates,
+    items,
+    sharingStatus,
+    edition,
+    activeParticipationId,
+    canDelete,
+  };
+}
+
+export function useTemplateSubmissionMutations({
+  editionId,
+  participationId,
+  template,
+  submission,
+  organizationId,
+  onSuccess,
+  setUploadProgress,
+}: {
+  editionId: string;
+  participationId: string;
+  template: TemplateItem;
+  submission: StatusItem['submission'] | null;
+  organizationId: string;
+  onSuccess: () => void;
+  setUploadProgress: (value: number | null) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      if (!submission) {
+        return;
+      }
+      const result = await apiClient.DELETE('/api/submissions/{id}', {
+        params: { path: { id: submission.id } },
+        headers: { 'X-Organization-Id': organizationId },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      toast.success('資料を削除しました');
+      await invalidateSubmissionStatusQueries(
+        queryClient,
+        editionId,
+        participationId,
+        organizationId,
+        submission?.id,
+      );
+      onSuccess();
+    },
+    onError: (err) => {
+      toast.error(getApiErrorMessage(err, 'submission'));
+    },
+  });
+
+  const uploadFileMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const validation = validateFile(file, template);
+      if (!validation.ok) {
+        throw new Error(validation.message);
+      }
+
+      const presignResult = await apiClient.POST('/api/upload/presign', {
+        body: {
+          participationId,
+          templateId: template.id,
+          fileName: file.name,
+          contentType: file.type,
+          fileSizeBytes: file.size,
+        },
+        headers: { 'X-Organization-Id': organizationId },
+      });
+      const presign = throwIfError(presignResult);
+
+      setUploadProgress(0);
+      await s3Put(presign.data.presignedUrl, file, setUploadProgress);
+
+      const body = {
+        s3Key: presign.data.s3Key,
+        fileName: file.name,
+        fileSizeBytes: file.size,
+        mimeType: file.type,
+      };
+
+      if (submission) {
+        const result = await apiClient.PUT('/api/submissions/{id}', {
+          params: { path: { id: submission.id } },
+          body,
+          headers: { 'X-Organization-Id': organizationId },
+        });
+        throwIfError(result);
+      } else {
+        const result = await apiClient.POST('/api/submissions', {
+          body: { ...body, templateId: template.id, participationId },
+          headers: { 'X-Organization-Id': organizationId },
+        });
+        throwIfError(result);
+      }
+    },
+    onSuccess: async () => {
+      setUploadProgress(null);
+      toast.success('資料をアップロードしました');
+      await invalidateSubmissionStatusQueries(
+        queryClient,
+        editionId,
+        participationId,
+        organizationId,
+        submission?.id,
+      );
+      onSuccess();
+    },
+    onError: (err) => {
+      setUploadProgress(null);
+      toast.error(err instanceof Error ? err.message : getApiErrorMessage(err, 'submission'));
+    },
+  });
+
+  const submitUrlMutation = useMutation({
+    mutationFn: async (url: string) => {
+      if (submission) {
+        const result = await apiClient.PUT('/api/submissions/{id}', {
+          params: { path: { id: submission.id } },
+          body: { url },
+          headers: { 'X-Organization-Id': organizationId },
+        });
+        throwIfError(result);
+      } else {
+        const result = await apiClient.POST('/api/submissions', {
+          body: { url, templateId: template.id, participationId },
+          headers: { 'X-Organization-Id': organizationId },
+        });
+        throwIfError(result);
+      }
+    },
+    onSuccess: async () => {
+      toast.success('URLを登録しました');
+      await invalidateSubmissionStatusQueries(
+        queryClient,
+        editionId,
+        participationId,
+        organizationId,
+        submission?.id,
+      );
+      onSuccess();
+    },
+    onError: (err) => {
+      toast.error(getApiErrorMessage(err, 'submission'));
+    },
+  });
+
+  return {
+    deleteMutation,
+    uploadFileMutation,
+    submitUrlMutation,
+  };
+}

--- a/apps/frontend/features/editions/team-detail/hooks.ts
+++ b/apps/frontend/features/editions/team-detail/hooks.ts
@@ -1,0 +1,157 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { useOrganization } from '@/contexts/OrganizationContext';
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateParticipationCommentsQueries } from '@/lib/query/invalidation';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+export type TeamSubmissionQueryParams = {
+  page: number;
+  pageSize: number;
+};
+
+export function useTeamDetailData(
+  participationId: string,
+  submissionParams: TeamSubmissionQueryParams,
+) {
+  const { organizationId } = useOrganization();
+  const { user } = useAuth();
+
+  const { data: participation, isLoading: participationLoading } = useQuery({
+    queryKey: queryKeys.participations.detail(participationId, organizationId ?? ''),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/participations/{id}', {
+        params: { path: { id: participationId } },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const { data: submissions, isLoading: submissionsLoading } = useQuery({
+    queryKey: queryKeys.participations.submissions(
+      participationId,
+      organizationId ?? '',
+      submissionParams,
+    ),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/participations/{id}/submissions', {
+        params: {
+          path: { id: participationId },
+          query: { page: submissionParams.page, pageSize: submissionParams.pageSize },
+        },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      return throwIfError(result);
+    },
+  });
+
+  const {
+    data: comments,
+    isLoading: commentsLoading,
+    error: commentsError,
+  } = useQuery({
+    queryKey: queryKeys.participations.comments(participationId, organizationId ?? '', {}),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/participations/{id}/comments', {
+        params: { path: { id: participationId }, query: { pageSize: 100 } },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      return throwIfError(result);
+    },
+  });
+
+  return {
+    organizationId,
+    user,
+    participation,
+    participationLoading,
+    submissions,
+    submissionsLoading,
+    comments,
+    commentsLoading,
+    commentsError,
+  };
+}
+
+export function useTeamCommentMutations({
+  participationId,
+  organizationId,
+  onPostSuccess,
+  onUpdateSuccess,
+}: {
+  participationId: string;
+  organizationId: string;
+  onPostSuccess: () => void;
+  onUpdateSuccess: () => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const postCommentMutation = useMutation({
+    mutationFn: async (body: string) => {
+      const result = await apiClient.POST('/api/participations/{id}/comments', {
+        params: { path: { id: participationId } },
+        body: { body },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      onPostSuccess();
+      await invalidateParticipationCommentsQueries(queryClient, participationId, organizationId);
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const updateCommentMutation = useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: string }) => {
+      const result = await apiClient.PUT('/api/comments/{id}', {
+        params: { path: { id } },
+        body: { body },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      onUpdateSuccess();
+      await invalidateParticipationCommentsQueries(queryClient, participationId, organizationId);
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const deleteCommentMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const result = await apiClient.DELETE('/api/comments/{id}', {
+        params: { path: { id } },
+        headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      await invalidateParticipationCommentsQueries(queryClient, participationId, organizationId);
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  return {
+    postCommentMutation,
+    updateCommentMutation,
+    deleteCommentMutation,
+  };
+}
+
+export async function downloadSubmission(
+  submissionId: string,
+  organizationId: string,
+): Promise<void> {
+  const result = await apiClient.GET('/api/submissions/{id}/download', {
+    params: { path: { id: submissionId } },
+    headers: organizationId ? { 'X-Organization-Id': organizationId } : {},
+  });
+  const data = throwIfError(result);
+  window.open(data.data.presignedUrl, '_blank');
+}

--- a/apps/frontend/features/public/auth/login/hooks.ts
+++ b/apps/frontend/features/public/auth/login/hooks.ts
@@ -1,0 +1,38 @@
+import { useInvalidateMe } from '@/contexts/AuthContext';
+import { authClient } from '@/lib/auth/client';
+import { useForm } from '@tanstack/react-form';
+import { useState } from 'react';
+import { z } from 'zod';
+
+export function useLoginForm(onSuccess: () => void) {
+  const invalidateMe = useInvalidateMe();
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: { email: '', password: '' },
+    onSubmit: async ({ value }) => {
+      setError(null);
+      const result = await authClient.signIn.email({
+        email: value.email,
+        password: value.password,
+      });
+
+      if (result.error) {
+        setError('メールアドレスまたはパスワードが正しくありません');
+        return;
+      }
+
+      await invalidateMe();
+      onSuccess();
+    },
+  });
+
+  return {
+    form,
+    error,
+    validators: {
+      email: z.string().email('有効なメールアドレスを入力してください'),
+      password: z.string().min(1, 'パスワードを入力してください'),
+    },
+  };
+}

--- a/apps/frontend/features/public/auth/register/hooks.ts
+++ b/apps/frontend/features/public/auth/register/hooks.ts
@@ -1,0 +1,47 @@
+import { useInvalidateMe } from '@/contexts/AuthContext';
+import { authClient } from '@/lib/auth/client';
+import { useForm } from '@tanstack/react-form';
+import { useState } from 'react';
+import { z } from 'zod';
+
+export function useRegisterForm(onSuccess: () => void) {
+  const invalidateMe = useInvalidateMe();
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: { name: '', email: '', password: '', confirmPassword: '' },
+    onSubmit: async ({ value }) => {
+      setError(null);
+      const result = await authClient.signUp.email({
+        name: value.name,
+        email: value.email,
+        password: value.password,
+      });
+
+      if (result.error) {
+        setError(result.error.message ?? 'アカウント作成に失敗しました');
+        return;
+      }
+
+      await invalidateMe();
+      onSuccess();
+    },
+  });
+
+  return {
+    form,
+    error,
+    validators: {
+      name: z.string().min(1, '名前を入力してください'),
+      email: z.string().email('有効なメールアドレスを入力してください'),
+      password: z.string().min(8, 'パスワードは8文字以上で入力してください'),
+      confirmPassword: ({ value, password }: { value: string; password: string }) => {
+        if (value !== password) {
+          return { message: 'パスワードが一致しません' };
+        }
+
+        return undefined;
+      },
+    },
+  };
+}

--- a/apps/frontend/features/public/competition-detail/query.ts
+++ b/apps/frontend/features/public/competition-detail/query.ts
@@ -1,0 +1,15 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { useQuery } from '@tanstack/react-query';
+
+export function useCompetitionDetail(editionId: string) {
+  return useQuery({
+    queryKey: queryKeys.editions.detail(editionId),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions/{id}', {
+        params: { path: { id: editionId } },
+      });
+      return throwIfError(result);
+    },
+  });
+}

--- a/apps/frontend/features/public/competitions/query.ts
+++ b/apps/frontend/features/public/competitions/query.ts
@@ -1,0 +1,35 @@
+import { apiClient, throwIfError } from '@/lib/api/client';
+import { queryKeys } from '@/lib/query/keys';
+import { useQuery } from '@tanstack/react-query';
+
+export type CompetitionsListParams = {
+  page: number;
+  pageSize: number;
+  q: string;
+};
+
+export function useCompetitionsSeries(params: CompetitionsListParams) {
+  return useQuery({
+    queryKey: queryKeys.series.all(params),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/series', {
+        params: {
+          query: { page: params.page, pageSize: params.pageSize, q: params.q || undefined },
+        },
+      });
+      return throwIfError(result);
+    },
+  });
+}
+
+export function useCompetitionsEditions() {
+  return useQuery({
+    queryKey: queryKeys.editions.all({ pageSize: 100 }),
+    queryFn: async () => {
+      const result = await apiClient.GET('/api/editions', {
+        params: { query: { pageSize: 100 } },
+      });
+      return throwIfError(result);
+    },
+  });
+}

--- a/apps/frontend/features/university/settings/hooks.ts
+++ b/apps/frontend/features/university/settings/hooks.ts
@@ -1,0 +1,125 @@
+import { useAuth } from '@/contexts/AuthContext';
+import { useOrganization } from '@/contexts/OrganizationContext';
+import { ApiError, apiClient, throwIfError } from '@/lib/api/client';
+import { invalidateUniversityMembersQueries } from '@/lib/query/invalidation';
+import { queryKeys } from '@/lib/query/keys';
+import { getApiErrorMessage } from '@/lib/utils/errors';
+import { useForm } from '@tanstack/react-form';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+export type Member = {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  role: 'owner' | 'member';
+  createdAt: unknown;
+};
+
+export function useUniversitySettingsPage() {
+  const { user } = useAuth();
+  const { organizationId, currentOrg } = useOrganization();
+  const queryClient = useQueryClient();
+  const canEdit = currentOrg?.role === 'owner' || user?.isAdmin;
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.university.members(organizationId ?? '', {}),
+    queryFn: async () => {
+      if (!organizationId) {
+        return null;
+      }
+      const result = await apiClient.GET('/api/university/members', {
+        params: { header: { 'x-organization-id': organizationId } },
+      });
+      return throwIfError(result);
+    },
+    enabled: !!organizationId,
+  });
+
+  const inviteMutation = useMutation({
+    mutationFn: async (values: { email: string; role: 'owner' | 'member' }) => {
+      const result = await apiClient.POST('/api/university/invite', {
+        params: { header: { 'x-organization-id': organizationId ?? '' } },
+        body: { email: values.email, role: values.role },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: () => {
+      toast.success('招待メールを送信しました');
+      inviteForm.reset();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const inviteForm = useForm({
+    defaultValues: { email: '', role: 'member' as 'owner' | 'member' },
+    onSubmit: async ({ value }) => {
+      await inviteMutation.mutateAsync(value);
+    },
+  });
+
+  const changeRoleMutation = useMutation({
+    mutationFn: async ({ memberId, role }: { memberId: string; role: string }) => {
+      const result = await apiClient.PUT('/api/university/members/{id}/role', {
+        params: { path: { id: memberId }, header: { 'x-organization-id': organizationId ?? '' } },
+        body: { role: role as 'owner' | 'member' },
+      });
+      return throwIfError(result);
+    },
+    onSuccess: async () => {
+      if (!organizationId) {
+        return;
+      }
+      await invalidateUniversityMembersQueries(queryClient, organizationId);
+    },
+    onError: (err) => {
+      const msg =
+        err instanceof ApiError && err.status === 409
+          ? '最後のオーナーは変更できません'
+          : getApiErrorMessage(err);
+      toast.error(msg);
+    },
+  });
+
+  const deleteMemberMutation = useMutation({
+    mutationFn: async (memberId: string) => {
+      const result = await apiClient.DELETE('/api/university/members/{id}', {
+        params: { path: { id: memberId }, header: { 'x-organization-id': organizationId ?? '' } },
+      });
+      if (!result.response.ok) {
+        throw new ApiError(result.response.status, result.error);
+      }
+    },
+    onSuccess: async () => {
+      if (!organizationId) {
+        return;
+      }
+      await invalidateUniversityMembersQueries(queryClient, organizationId);
+      toast.success('メンバーを削除しました');
+    },
+    onError: (err) => {
+      const msg =
+        err instanceof ApiError && err.status === 409
+          ? '最後のオーナーは削除できません'
+          : getApiErrorMessage(err);
+      toast.error(msg);
+    },
+  });
+
+  return {
+    user,
+    currentOrg,
+    canEdit,
+    data,
+    isLoading,
+    inviteForm,
+    inviteMutation,
+    changeRoleMutation,
+    deleteMemberMutation,
+    validators: {
+      email: z.string().email('有効なメールアドレスを入力してください'),
+    },
+  };
+}

--- a/apps/frontend/lib/query/invalidation.test.ts
+++ b/apps/frontend/lib/query/invalidation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  invalidateSubmissionStatusQueries,
+  invalidateUniversityMembersQueries,
+} from './invalidation';
+import { queryKeys } from './keys';
+
+function createQueryClientMock() {
+  return {
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('query invalidation helpers', () => {
+  it('invalidates university members by membersPrefix', async () => {
+    const queryClient = createQueryClientMock();
+
+    await invalidateUniversityMembersQueries(queryClient as never, 'org-1');
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.university.membersPrefix('org-1'),
+    });
+  });
+
+  it('invalidates submission history by historyPrefix when submissionId exists', async () => {
+    const queryClient = createQueryClientMock();
+
+    await invalidateSubmissionStatusQueries(
+      queryClient as never,
+      'edition-1',
+      'participation-1',
+      'org-1',
+      'submission-1',
+    );
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.submissions.historyPrefix('submission-1', 'org-1'),
+    });
+  });
+
+  it('does not invalidate submission history when submissionId is missing', async () => {
+    const queryClient = createQueryClientMock();
+
+    await invalidateSubmissionStatusQueries(
+      queryClient as never,
+      'edition-1',
+      'participation-1',
+      'org-1',
+    );
+
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: queryKeys.submissions.historyPrefix('submission-1', 'org-1'),
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/frontend/lib/query/invalidation.ts
+++ b/apps/frontend/lib/query/invalidation.ts
@@ -21,3 +21,62 @@ export async function invalidateAdminTemplatesQueries(
 ): Promise<void> {
   await queryClient.invalidateQueries({ queryKey: queryKeys.admin.templatesPrefix(editionId) });
 }
+
+export async function invalidateAdminParticipationsQueries(
+  queryClient: QueryClient,
+  editionId: string,
+): Promise<void> {
+  await queryClient.invalidateQueries({
+    queryKey: queryKeys.admin.participationsPrefix(editionId),
+  });
+}
+
+export async function invalidateAdminUsersQueries(queryClient: QueryClient): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: queryKeys.admin.usersPrefix() });
+}
+
+export async function invalidateAdminUniversitiesQueries(queryClient: QueryClient): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: queryKeys.admin.universitiesPrefix() });
+}
+
+export async function invalidateUniversityMembersQueries(
+  queryClient: QueryClient,
+  orgId: string,
+): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: queryKeys.university.membersPrefix(orgId) });
+}
+
+export async function invalidateParticipationCommentsQueries(
+  queryClient: QueryClient,
+  participationId: string,
+  orgId: string,
+): Promise<void> {
+  await queryClient.invalidateQueries({
+    queryKey: queryKeys.participations.comments(participationId, orgId, {}),
+  });
+}
+
+export async function invalidateSubmissionStatusQueries(
+  queryClient: QueryClient,
+  editionId: string,
+  participationId: string,
+  orgId: string,
+  submissionId?: string,
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.editions.mySubmissionStatus(editionId, orgId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.editions.submissionMatrixPrefix(editionId, orgId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: queryKeys.participations.submissionsPrefix(participationId, orgId),
+    }),
+    submissionId
+      ? queryClient.invalidateQueries({
+          queryKey: queryKeys.submissions.historyPrefix(submissionId, orgId),
+        })
+      : Promise.resolve(),
+  ]);
+}

--- a/apps/frontend/lib/query/invalidation.ts
+++ b/apps/frontend/lib/query/invalidation.ts
@@ -1,0 +1,23 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { queryKeys } from './keys';
+
+export async function invalidateAdminSeriesQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.admin.seriesPrefix() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.series.prefix() }),
+  ]);
+}
+
+export async function invalidateAdminEditionsQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.admin.editionsPrefix() }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.editions.prefix() }),
+  ]);
+}
+
+export async function invalidateAdminTemplatesQueries(
+  queryClient: QueryClient,
+  editionId: string,
+): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: queryKeys.admin.templatesPrefix(editionId) });
+}

--- a/apps/frontend/lib/query/keys.ts
+++ b/apps/frontend/lib/query/keys.ts
@@ -5,12 +5,16 @@ export const queryKeys = {
   me: ['me'] as const,
 
   series: {
+    prefix: () => ['series'] as const,
     all: (params: Record<string, unknown>) => ['series', params] as const,
+    allForSelection: () => ['series', { pageSize: 100 }] as const,
     detail: (id: string) => ['series', id] as const,
   },
 
   editions: {
+    prefix: () => ['editions'] as const,
     all: (params: Record<string, unknown>) => ['editions', params] as const,
+    allForSelection: () => ['editions', { pageSize: 100 }] as const,
     detail: (id: string) => ['editions', id] as const,
     templates: (id: string, params: Record<string, unknown>) =>
       ['editions', id, 'templates', params] as const,
@@ -45,10 +49,13 @@ export const queryKeys = {
   },
 
   admin: {
+    seriesPrefix: () => ['admin', 'series'] as const,
     series: (params: Record<string, unknown>) => ['admin', 'series', params] as const,
+    editionsPrefix: () => ['admin', 'editions'] as const,
     editions: (params: Record<string, unknown>) => ['admin', 'editions', params] as const,
     participations: (editionId: string, params: Record<string, unknown>) =>
       ['admin', 'editions', editionId, 'participations', params] as const,
+    templatesPrefix: (editionId: string) => ['admin', 'editions', editionId, 'templates'] as const,
     templates: (editionId: string, params: Record<string, unknown>) =>
       ['admin', 'editions', editionId, 'templates', params] as const,
     universities: (params: Record<string, unknown>) => ['admin', 'universities', params] as const,

--- a/apps/frontend/lib/query/keys.ts
+++ b/apps/frontend/lib/query/keys.ts
@@ -24,6 +24,8 @@ export const queryKeys = {
       ['editions', id, 'my-submissions', orgId, params] as const,
     mySubmissionStatus: (id: string, orgId: string) =>
       ['editions', id, 'my-submission-status', orgId] as const,
+    submissionMatrixPrefix: (id: string, orgId: string) =>
+      ['editions', id, 'submission-matrix', orgId] as const,
     submissions: (id: string, orgId: string, params: Record<string, unknown>) =>
       ['editions', id, 'submissions', orgId, params] as const,
     submissionMatrix: (id: string, orgId: string, params: Record<string, unknown>) =>
@@ -31,7 +33,10 @@ export const queryKeys = {
   },
 
   participations: {
+    prefix: (id: string, orgId: string) => ['participations', id, orgId] as const,
     detail: (id: string, orgId: string) => ['participations', id, orgId] as const,
+    submissionsPrefix: (id: string, orgId: string) =>
+      ['participations', id, 'submissions', orgId] as const,
     submissions: (id: string, orgId: string, params: Record<string, unknown>) =>
       ['participations', id, 'submissions', orgId, params] as const,
     comments: (id: string, orgId: string, params: Record<string, unknown>) =>
@@ -39,13 +44,18 @@ export const queryKeys = {
   },
 
   submissions: {
+    prefix: (id: string) => ['submissions', id] as const,
+    historyPrefix: (id: string, orgId: string) => ['submissions', id, 'history', orgId] as const,
     history: (id: string, orgId: string, params: Record<string, unknown>) =>
-      ['submissions', id, 'history', orgId, params] as const,
+      [...queryKeys.submissions.historyPrefix(id, orgId), params] as const,
   },
 
   university: {
+    prefix: (orgId: string) => ['university', orgId] as const,
+    membersPrefix: (orgId?: string) =>
+      orgId ? (['university', 'members', orgId] as const) : (['university', 'members'] as const),
     members: (orgId: string, params: Record<string, unknown>) =>
-      ['university', 'members', orgId, params] as const,
+      [...queryKeys.university.membersPrefix(orgId), params] as const,
   },
 
   admin: {
@@ -55,10 +65,14 @@ export const queryKeys = {
     editions: (params: Record<string, unknown>) => ['admin', 'editions', params] as const,
     participations: (editionId: string, params: Record<string, unknown>) =>
       ['admin', 'editions', editionId, 'participations', params] as const,
+    participationsPrefix: (editionId: string) =>
+      ['admin', 'editions', editionId, 'participations'] as const,
     templatesPrefix: (editionId: string) => ['admin', 'editions', editionId, 'templates'] as const,
     templates: (editionId: string, params: Record<string, unknown>) =>
       ['admin', 'editions', editionId, 'templates', params] as const,
+    universitiesPrefix: () => ['admin', 'universities'] as const,
     universities: (params: Record<string, unknown>) => ['admin', 'universities', params] as const,
+    usersPrefix: () => ['admin', 'users'] as const,
     users: (params: Record<string, unknown>) => ['admin', 'users', params] as const,
     userMemberships: (userId: string) => ['admin', 'users', userId, 'memberships'] as const,
   },

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['lib/**/*.test.ts'],
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -2,5 +2,6 @@ import { defineWorkspace } from 'vitest/config';
 
 export default defineWorkspace([
   'apps/backend/vitest.config.ts',
+  'apps/frontend/vitest.config.ts',
   'packages/shared/vitest.config.ts',
 ]);


### PR DESCRIPTION
## 概要
TanStack Query/Form の責務分離を、前PRで未対応だった残ページ全体へ横展開しました。page は表示・イベント配線に集中させ、API 呼び出し / query / mutation / form ロジックは features 配下へ移譲しています。

Closes #27

## 主要変更点
- 対象12ページへ横展開
  - app/(admin)/admin/editions/[id]/participations/page.tsx
  - app/(admin)/admin/universities/page.tsx
  - app/(admin)/admin/users/page.tsx
  - app/(authenticated)/account/settings/page.tsx
  - app/(authenticated)/dashboard/page.tsx
  - app/(authenticated)/editions/[id]/submit/page.tsx
  - app/(authenticated)/editions/[id]/teams/[participationId]/page.tsx
  - app/(authenticated)/university/settings/page.tsx
  - app/(public)/auth/login/page.tsx
  - app/(public)/auth/register/page.tsx
  - app/(public)/competitions/[editionId]/page.tsx
  - app/(public)/competitions/page.tsx
- Query Key / invalidation の共通化を拡張
  - lib/query/keys.ts: prefix キーを追加し、再利用可能なキー構造へ整理
  - lib/query/invalidation.ts: 参加・ユーザー・大学・提出関連の invalidation 関数を追加
- features 追加
  - features/account/settings/hooks.ts
  - features/admin/participations/hooks.ts
  - features/admin/universities/hooks.ts
  - features/admin/users/hooks.ts
  - features/dashboard/query.ts
  - features/editions/submit/hooks.ts
  - features/editions/team-detail/hooks.ts
  - features/public/auth/login/hooks.ts
  - features/public/auth/register/hooks.ts
  - features/public/competition-detail/query.ts
  - features/public/competitions/query.ts
  - features/university/settings/hooks.ts

## 検証結果
- pnpm --filter frontend typecheck : 成功
- pnpm check : 成功
- pnpm test（frontend test実行対象化後）: 成功
  - apps/frontend/vitest.config.ts を追加
  - vitest.workspace.ts に frontend project を追加
  - apps/frontend/lib/query/invalidation.test.ts を追加

## 追加対応（Issue #28）
- 追加対応Issue: #28
- 対象ページ: app/(authenticated)/editions/[id]/submissions/[submissionId]/history/page.tsx
- 新規hook: features/editions/submission-history/hooks.ts
- 残存確認: app配下 page.tsx の useQuery/useMutation 検索結果 0件
- 検証: pnpm --filter frontend typecheck, pnpm check

Closes #28
