### PR TITLE
資料一覧のデフォルト表示件数を100に変更

### DIFF
--- a/apps/frontend/components/common/PaginationControls.tsx
+++ b/apps/frontend/components/common/PaginationControls.tsx
@@ -24,7 +24,7 @@ interface PaginationControlsProps {
   onPageSizeChange: (pageSize: number) => void;
 }
 
-const PAGE_SIZE_OPTIONS = [10, 20, 50];
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
 
 export function PaginationControls({
   pagination,

--- a/apps/frontend/components/editions/EditionSubmissionMatrix.tsx
+++ b/apps/frontend/components/editions/EditionSubmissionMatrix.tsx
@@ -38,7 +38,7 @@ const matrixSortLabelMap: Record<(typeof matrixSortValues)[number], string> = {
 
 const paginationParsers = {
   page: parseAsInteger.withDefault(1),
-  pageSize: parseAsInteger.withDefault(20),
+  pageSize: parseAsInteger.withDefault(100),
   q: parseAsString.withDefault(''),
   sort: parseAsStringEnum([...matrixSortValues]).withDefault('createdAt:asc'),
 };


### PR DESCRIPTION
## Summary
- 資料一覧 (`EditionSubmissionMatrix`) のデフォルト pageSize を 20 → 100 に変更
- ページサイズ選択肢に 100 を追加（バックエンドの `MAX_PAGE_SIZE` も 100 のため上限内）

## Test plan
- [ ] 資料一覧ページを開いて初期表示が 100 件になっていることを確認
- [ ] ページサイズ選択肢に 10/20/50/100 が表示され、それぞれ選択して切り替えできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)